### PR TITLE
Add basic support for unix socket-based RPC

### DIFF
--- a/config/tmux.conf
+++ b/config/tmux.conf
@@ -1,0 +1,5 @@
+# Enable RGB colour if running in xterm(1)
+set-option -g default-terminal "tmux-256color"
+set-option -sa terminal-overrides ",xterm*:Tc"
+
+

--- a/config/tmux.conf
+++ b/config/tmux.conf
@@ -2,4 +2,4 @@
 set-option -g default-terminal "tmux-256color"
 set-option -sa terminal-overrides ",xterm*:Tc"
 
-
+set-option -g status off

--- a/lua/kodachi/init.lua
+++ b/lua/kodachi/init.lua
@@ -68,7 +68,11 @@ function M.buf_request(request)
 
   local socket = M.sockets[vim.b.kodachi.socket]
   socket:write(to_write)
-  -- vim.fn.chansend(vim.b.kodachi.job_id, to_write)
+end
+
+function M.buf_send(text)
+  -- TODO: Get the connection ID from the buffer
+  M.buf_request { type = "Send", connection = 0, text = text }
 end
 
 return M

--- a/lua/kodachi/init.lua
+++ b/lua/kodachi/init.lua
@@ -23,12 +23,16 @@ function M.buf_connect(uri)
     vim.cmd [[ enew ]]
   end
 
+  -- NOTE: Neovim does not correctly persist output if the window resizes smaller
+  -- than the width of the text, so we use tmux to save it
+  local tmux_wrap = vim.fn.has('nvim')
+
   local socket = require'kodachi.socket'.create()
   M.sockets[socket.name] = socket
 
   local state = { socket = socket.name }
   local cmd = vim.tbl_flatten {
-    M.debug and {} or { 'tmux', 'new-session', '-f', kodachi_tmux, '-n', 'kodachi' },
+    tmux_wrap and { 'tmux', '-f', kodachi_tmux, 'new-session', '-n', 'kodachi' } or {},
     M.debug and { 'cargo', 'run', '--' } or kodachi_exe,
     'unix', socket.name,
   }

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -1,0 +1,34 @@
+local Socket = {}
+
+function Socket:new(name, from_app, to_app)
+  local o = { name = name, from_app = from_app, to_app = to_app}
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function Socket:write(data)
+  self.to_app:write(data)
+end
+
+local M = {}
+
+---@param name string|nil Preferred name of the unix domain socket; if not provided
+-- or nil, `tempname()` will be used
+function M.create(name)
+  local path = name or vim.fn.tempname()
+  local from_app = vim.loop.new_pipe(false)
+  local to_app = vim.loop.new_pipe(false)
+
+  local socket = Socket:new(path, from_app, to_app)
+
+  from_app:bind(path)
+  from_app:listen(16, function ()
+    from_app:accept(to_app)
+    print('Received connection...')
+  end)
+
+  return socket
+end
+
+return M

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -42,7 +42,6 @@ function M.create(name)
 
   from_app:bind(path)
   from_app:listen(16, function ()
-    print('Received connection...')
     from_app:accept(to_app)
     socket:_on_connected()
   end)

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -5,7 +5,10 @@ function Socket:new(name, from_app, to_app)
     name = name,
     from_app = from_app,
     to_app = to_app,
-    to_app_queue = {},
+    _next_request_id = 0,
+    _to_app_queue = {},
+    _receivers = {},
+    _received_data = '',
   }
 
   setmetatable(o, self)
@@ -13,20 +16,75 @@ function Socket:new(name, from_app, to_app)
   return o
 end
 
+function Socket:next_request_id()
+  local id = self._next_request_id
+  self._next_request_id = id + 1
+  return id
+end
+
+function Socket:listen(handler)
+  table.insert(self._receivers, handler)
+end
+
+function Socket:unlisten(handler)
+  local index = nil
+  for i, candidate in ipairs(self._receivers) do
+    if candidate == handler then
+      index = i
+      break
+    end
+  end
+
+  if index then
+    table.remove(self._receivers, index)
+  end
+end
+
+function Socket:listen_matched_once(matcher, handler)
+  local socket = self
+  local function listener(message)
+    if matcher(message) then
+      handler(message)
+      socket:unlisten(listener)
+    end
+  end
+
+  socket:listen(listener)
+end
+
+function Socket:await_request_id(id, handler)
+  local function matcher(message)
+    return message.request_id == id
+  end
+  self:listen_matched_once(matcher, handler)
+end
+
 function Socket:write(data)
   if self.connected then
     self.to_app:write(data)
   else
-    table.insert(self.to_app_queue, data)
+    table.insert(self._to_app_queue, data)
   end
 end
 
 function Socket:_on_connected()
   self.connected = true
-  for _, item in ipairs(self.to_app_queue) do
+  for _, item in ipairs(self._to_app_queue) do
     self:write(item)
   end
-  self.to_app_queue = {}
+  self._to_app_queue = {}
+end
+
+function Socket:_on_read(chunk)
+  self._received_data = self._received_data .. chunk
+  if vim.endswith(self._received_data, '\n') then
+    -- TODO: Dispatch
+    local parsed = vim.json.decode(self._received_data)
+    for _, receiver in ipairs(self._receivers) do
+      receiver(parsed)
+    end
+  end
+  self._received_data = ''
 end
 
 local M = {}
@@ -35,15 +93,27 @@ local M = {}
 -- or nil, `tempname()` will be used
 function M.create(name)
   local path = name or vim.fn.tempname()
-  local from_app = vim.loop.new_pipe(false)
-  local to_app = vim.loop.new_pipe(false)
+  local server = vim.loop.new_pipe(false)
+  local client = vim.loop.new_pipe(false)
 
-  local socket = Socket:new(path, from_app, to_app)
+  local socket = Socket:new(path, server, client)
 
-  from_app:bind(path)
-  from_app:listen(16, function ()
-    from_app:accept(to_app)
+  server:bind(path)
+  server:listen(16, function ()
+    server:accept(client)
     socket:_on_connected()
+
+    client:read_start(function (err, chunk)
+      assert(not err, err) -- TODO: Handle errors better?
+      if chunk then
+        socket:_on_read(chunk)
+      else
+        -- EOF:
+        socket.connected = false
+        server:close()
+        client:close()
+      end
+    end)
   end)
 
   return socket

--- a/src/net/uri.rs
+++ b/src/net/uri.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use url::Url;
 
+#[derive(Debug)]
 pub struct Uri {
     pub host: String,
     pub port: u16,


### PR DESCRIPTION
The lua side is a bit rough, but functional! We can listen to JSON RPC messages from Rust and act on them, and use tmux to wrap the Rust output and preserve it on nvim. We don't yet change behavior for Vim, where we could simply run the CLI app in stdio mode and redirect stderr (and which probably doesn't support this unix socket server stuff anyway).

- Begin experiments with hosting a unix domain socket from nvim
- Ensure writes to Socket are enqueued
- Provide our own tmux config
- Improve error visibility
- Fix tmux config passing; disable tmux statusbar
- Add buf_send util for sending text to the buffer's connection
- Make Uri debuggable
- Minor cleanup
- Support receiving events from Rust; use the connection_id
