### PR TITLE
Add basic Trigger support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 name = "kodachi"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "clap",
  "delegate",
  "native-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -99,6 +99,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "delegate"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,7 +167,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -199,6 +224,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "clap",
+ "crossterm",
  "delegate",
  "native-tls",
  "regex",
@@ -222,6 +248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +279,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "mio"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +317,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -316,6 +384,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -476,6 +567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +625,42 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"
@@ -672,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,3 +840,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "3.1.7", features = ["derive"] }
 bytes = "1.1.0"
+crossterm = "0.23.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ regex = "1.5.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "3.1.7", features = ["derive"] }
+bytes = "1.1.0"

--- a/lua/kodachi/connection.lua
+++ b/lua/kodachi/connection.lua
@@ -7,16 +7,16 @@ local M = {}
 function M.run(state, uri)
   state.socket:request(
     { type = 'Connect', uri = uri },
-    function (response)
-      state.connection_id = response.id
+    function(response)
+      state.connection_id = response.connection_id
     end
   )
 
   state.socket:listen_matched_once(
-    function (event)
+    function(event)
       return event.type == 'Disconnected' and event.connection_id == state.connection_id
     end,
-    function ()
+    function()
       state.connection_id = nil
     end
   )

--- a/lua/kodachi/handlers.lua
+++ b/lua/kodachi/handlers.lua
@@ -1,0 +1,37 @@
+---@class Handlers
+---@field _entries any
+---@field _next_id number
+local Handlers = {}
+
+function Handlers:new()
+  local o = {
+    _entries = {},
+    _next_id = 0,
+  }
+
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function Handlers:clear()
+  self._entries = {}
+  self._next_id = 0
+end
+
+function Handlers:insert(handler)
+  local id = self._next_id
+  self._next_id = id + 1
+  self._entries[id] = handler
+  return id
+end
+
+function Handlers:remove_by_id(id)
+  self._entries[id] = nil
+end
+
+function Handlers:get(id)
+  return self._entries[id]
+end
+
+return Handlers

--- a/lua/kodachi/init.lua
+++ b/lua/kodachi/init.lua
@@ -3,13 +3,13 @@ local M = {}
 ---Open a connection to the given URI in the current buffer
 ---@param uri string
 function M.connect(uri)
-  local state = require'kodachi.ui'.ensure_window()
+  local state = require 'kodachi.ui'.ensure_window()
   if not state then
     return
   end
 
   state.uri = uri
-  require'kodachi.connection'.run(state, uri)
+  require 'kodachi.connection'.run(state, uri)
 
   return state
 end
@@ -20,7 +20,7 @@ end
 -- If called when a connection exists for another URI, this function is a nop
 -- (and the callback will not be called).
 function M.with_connection(uri, on_connection)
-  local state = require'kodachi.states'.current { silent = true }
+  local state = require 'kodachi.states'.current { silent = true }
 
   if state and state.connection_id and state.uri and state.uri ~= uri then
     -- Already connected, but to another URI
@@ -28,16 +28,18 @@ function M.with_connection(uri, on_connection)
   elseif not (state and state.connection_id) then
     -- Not connected yet
     state = M.connect(uri)
-    state.socket:listen_matched_once(
-      function (message)
-        return message.type == 'Connected'
-      end,
-      vim.schedule_wrap(function ()
-        state.just_connected = true
-        on_connection(state)
-        state.just_connected = nil
-      end)
-    )
+    if state then
+      state.socket:listen_matched_once(
+        function(message)
+          return message.type == 'Connected'
+        end,
+        vim.schedule_wrap(function()
+          state.just_connected = true
+          on_connection(state)
+          state.just_connected = nil
+        end)
+      )
+    end
   else
     -- Already connected to this URI
     state:cleanup()

--- a/lua/kodachi/init.lua
+++ b/lua/kodachi/init.lua
@@ -40,6 +40,7 @@ function M.with_connection(uri, on_connection)
     )
   else
     -- Already connected to this URI
+    state:cleanup()
     on_connection(state)
   end
 end

--- a/lua/kodachi/matchers.lua
+++ b/lua/kodachi/matchers.lua
@@ -1,0 +1,38 @@
+---@alias MatcherSpec { type:'regex', source:string }
+
+local M = {}
+
+---@param matcher MatcherSpec|string
+function M.inflate(matcher)
+  local matcher_type = type(matcher)
+  if matcher_type == 'table' then
+    return matcher
+  elseif matcher_type == 'string' then
+    return M.simple(matcher)
+  else
+    error("Invalid matcher type: " .. matcher_type)
+  end
+end
+
+---Create a matcher using the regex syntax of the Rust lang `regex` library
+---@param pattern string A perl-like regex pattern.
+---@return MatcherSpec
+function M.regex(pattern)
+  return {
+    type = 'regex',
+    source = pattern,
+  }
+end
+
+---Create a matcher using "simple" syntax
+---@param pattern string A "simple" matcher pattern
+---@return MatcherSpec
+function M.simple(pattern)
+  return {
+    type = 'simple',
+    source = pattern,
+  }
+end
+
+
+return M

--- a/lua/kodachi/matchers.lua
+++ b/lua/kodachi/matchers.lua
@@ -19,7 +19,7 @@ end
 ---@return MatcherSpec
 function M.regex(pattern)
   return {
-    type = 'regex',
+    type = 'Regex',
     source = pattern,
   }
 end
@@ -29,7 +29,7 @@ end
 ---@return MatcherSpec
 function M.simple(pattern)
   return {
-    type = 'simple',
+    type = 'Simple',
     source = pattern,
   }
 end

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -115,7 +115,6 @@ function Socket:_on_read(chunk)
 
       local ok, result = pcall(vim.json.decode, to_parse)
       if ok then
-        vim.g.last = result
         for _, receiver in ipairs(self._receivers) do
           receiver(result)
         end

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -22,6 +22,7 @@ function Socket:new(name, from_app, to_app)
   return o
 end
 
+---@param handler fun(message:KodachiRequest)
 function Socket:listen(handler)
   table.insert(self._receivers, handler)
 end

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -57,6 +57,7 @@ function Socket:await_request_id(id, handler)
   local function matcher(message)
     return message.request_id == id
   end
+
   self:listen_matched_once(matcher, handler)
 end
 
@@ -114,6 +115,7 @@ function Socket:_on_read(chunk)
 
       local ok, result = pcall(vim.json.decode, to_parse)
       if ok then
+        vim.g.last = result
         for _, receiver in ipairs(self._receivers) do
           receiver(result)
         end
@@ -137,11 +139,11 @@ function M.create(name)
   local socket = Socket:new(path, server, client)
 
   server:bind(path)
-  server:listen(16, function ()
+  server:listen(16, function()
     server:accept(client)
     socket:_on_connected()
 
-    client:read_start(function (err, chunk)
+    client:read_start(function(err, chunk)
       assert(not err, err) -- TODO: Handle errors better?
       if chunk then
         socket:_on_read(chunk)

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -86,7 +86,7 @@ function KodachiState:trigger(matcher, handler)
     if not self._triggers then
       self._triggers = Handlers:new()
       socket:listen(function (message)
-        if message.type == 'TriggerFired' then
+        if message.type == 'TriggerFired' and message.connection == self.connection_id then
           local triggered_handler = self._triggers:get(message.trigger)
           if triggered_handler then
             vim.schedule(function ()
@@ -100,6 +100,7 @@ function KodachiState:trigger(matcher, handler)
     local id = self._triggers:insert(handler)
     socket:request {
       type = "RegisterTrigger",
+      connection = self.connection_id,
       matcher = matcher,
       handler_id = id,
     }

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -37,7 +37,7 @@ function KodachiState:cleanup()
     if self.socket and self.connection_id then
       self.socket:notify {
         type = "Clear",
-        connection = self.connection_id,
+        connection_id = self.connection_id,
       }
     end
   end
@@ -110,7 +110,7 @@ function KodachiState:trigger(matcher, handler)
     local id = self._triggers:insert(handler)
     socket:request {
       type = "RegisterTrigger",
-      connection = self.connection_id,
+      connection_id = self.connection_id,
       matcher = matcher,
       handler_id = id,
     }
@@ -123,7 +123,7 @@ function KodachiState:send(text)
   return with_socket(self, function(socket)
     socket:request {
       type = "Send",
-      connection = self.connection_id,
+      connection_id = self.connection_id,
       text = text,
     }
   end)

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -34,6 +34,12 @@ end
 function KodachiState:cleanup()
   if self._triggers then
     self._triggers:clear()
+    if self.socket and self.connection_id then
+      self.socket:notify {
+        type = "Clear",
+        connection = self.connection_id,
+      }
+    end
   end
 end
 

--- a/src/app/clearable.rs
+++ b/src/app/clearable.rs
@@ -1,0 +1,3 @@
+pub trait Clearable {
+    fn clear(&mut self);
+}

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -1,22 +1,32 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use tokio::sync::mpsc;
 
-use super::Id;
+use super::{processing::text::TextProcessor, Id};
 
 pub enum Outgoing {
     Text(String),
     Disconnect,
 }
 
+#[derive(Default)]
+pub struct ConnectionState {
+    pub processor: TextProcessor,
+}
+
 #[derive(Clone)]
 pub struct Connection {
     pub outbox: mpsc::Sender<Outgoing>,
+    pub shared_state: Arc<Mutex<ConnectionState>>,
 }
 
 pub struct ConnectionReceiver {
     pub id: Id,
     pub outbox: mpsc::Receiver<Outgoing>,
+    pub shared_state: Arc<Mutex<ConnectionState>>,
 }
 
 #[derive(Default)]
@@ -30,12 +40,18 @@ impl Connections {
         let id = self.allocate_id();
         let (outbox_tx, outbox_rx) = mpsc::channel(1);
 
-        let connection = Connection { outbox: outbox_tx };
+        let state = ConnectionState::default();
+        let connection = Connection {
+            outbox: outbox_tx,
+            shared_state: Arc::new(Mutex::new(state)),
+        };
+        let state_ref = connection.shared_state.clone();
         self.connections.insert(id, connection);
 
         ConnectionReceiver {
             id,
             outbox: outbox_rx,
+            shared_state: state_ref,
         }
     }
 
@@ -46,6 +62,14 @@ impl Connections {
     pub fn get_outbox(&mut self, id: Id) -> Option<mpsc::Sender<Outgoing>> {
         if let Some(conn) = self.connections.get(&id) {
             Some(conn.outbox.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_state(&mut self, id: Id) -> Option<Arc<Mutex<ConnectionState>>> {
+        if let Some(conn) = self.connections.get(&id) {
+            Some(conn.shared_state.clone())
         } else {
             None
         }

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use regex::Regex;
 use serde::Deserialize;
 
 use super::processing::ansi::Ansi;
@@ -30,4 +33,45 @@ pub enum MatchResult {
     Consumed {
         remaining: Ansi,
     },
+}
+
+pub struct Matcher {
+    options: MatcherOptions,
+    pattern: Regex,
+}
+
+impl Matcher {
+    pub fn try_match(&self, subject: Ansi) -> MatchResult {
+        if let Some(_found) = self.pattern.find(&subject) {
+            if self.options.consume {
+                // TODO: Consume
+                return MatchResult::Consumed { remaining: subject };
+            }
+
+            // TODO extract vars from "found"
+        }
+        MatchResult::Ignored(subject)
+    }
+}
+
+#[derive(Debug)]
+pub enum MatcherCompileError {
+    SyntaxError(String),
+
+    /// TODO
+    Unsupported,
+}
+
+impl TryInto<Matcher> for MatcherSpec {
+    type Error = MatcherCompileError;
+
+    fn try_into(self) -> Result<Matcher, Self::Error> {
+        match self {
+            MatcherSpec::Simple { .. } => Err(MatcherCompileError::Unsupported),
+            MatcherSpec::Regex { options, source } => match Regex::from_str(&source) {
+                Ok(pattern) => Ok(Matcher { options, pattern }),
+                Err(e) => Err(MatcherCompileError::SyntaxError(e.to_string())),
+            },
+        }
+    }
 }

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use super::processing::ansi::Ansi;
+
 #[derive(Debug, Deserialize)]
 pub struct MatcherOptions {
     #[serde(default)]
@@ -18,5 +20,14 @@ pub enum MatcherSpec {
         #[serde(flatten)]
         options: MatcherOptions,
         source: String,
+    },
+}
+
+pub enum MatchResult {
+    Ignored(Ansi),
+
+    /// Some (or all) of the input was consumed; [remaining] contains any remaining text
+    Consumed {
+        remaining: Ansi,
     },
 }

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -1,11 +1,11 @@
-use std::str::FromStr;
+use std::collections::HashMap;
 
-use regex::Regex;
+use regex::{Captures, Regex};
 use serde::Deserialize;
 
 use super::processing::ansi::Ansi;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct MatcherOptions {
     #[serde(default)]
     pub consume: bool,
@@ -26,8 +26,20 @@ pub enum MatcherSpec {
     },
 }
 
+#[derive(PartialEq, Eq, Hash)]
+pub enum MatchVariable {
+    Index(usize),
+    Name(String),
+}
+
 pub enum MatchResult {
     Ignored(Ansi),
+
+    Matched {
+        remaining: Ansi,
+        full_match: Ansi,
+        variables: HashMap<MatchVariable, Ansi>,
+    },
 
     /// Some (or all) of the input was consumed; [remaining] contains any remaining text
     Consumed {
@@ -35,6 +47,7 @@ pub enum MatchResult {
     },
 }
 
+#[derive(Debug)]
 pub struct Matcher {
     options: MatcherOptions,
     pattern: Regex,
@@ -42,15 +55,51 @@ pub struct Matcher {
 
 impl Matcher {
     pub fn try_match(&self, subject: Ansi) -> MatchResult {
-        if let Some(_found) = self.pattern.find(&subject) {
+        if let Some(found) = self.pattern.captures(&subject) {
             if self.options.consume {
                 // TODO: Consume
                 return MatchResult::Consumed { remaining: subject };
             }
 
-            // TODO extract vars from "found"
+            // TODO: Map pattern range back to Ansi bytes range
+            let full_match = Ansi::from(found.get(0).unwrap().as_str());
+            let remaining = subject.clone();
+
+            let variables = self.extract_match_variables(found);
+
+            return MatchResult::Matched {
+                remaining,
+                full_match,
+                variables,
+            };
         }
+
+        println!("pattern {:?} did not find", self.pattern);
         MatchResult::Ignored(subject)
+    }
+
+    fn extract_match_variables(&self, captures: Captures) -> HashMap<MatchVariable, Ansi> {
+        let mut result = HashMap::default();
+
+        for i in 0..captures.len() {
+            result.insert(
+                MatchVariable::Index(i),
+                Ansi::from(captures.get(i).unwrap().as_str()),
+            );
+        }
+
+        for name in self.pattern.capture_names() {
+            if let Some(n) = name {
+                if let Some(captured) = captures.name(n) {
+                    result.insert(
+                        MatchVariable::Name(n.to_string()),
+                        Ansi::from(captured.as_str()),
+                    );
+                }
+            }
+        }
+
+        return result;
     }
 }
 
@@ -68,10 +117,66 @@ impl TryInto<Matcher> for MatcherSpec {
     fn try_into(self) -> Result<Matcher, Self::Error> {
         match self {
             MatcherSpec::Simple { .. } => Err(MatcherCompileError::Unsupported),
-            MatcherSpec::Regex { options, source } => match Regex::from_str(&source) {
+            MatcherSpec::Regex { options, source } => match Regex::new(&source) {
                 Ok(pattern) => Ok(Matcher { options, pattern }),
                 Err(e) => Err(MatcherCompileError::SyntaxError(e.to_string())),
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_matches_test() {
+        let spec = MatcherSpec::Regex {
+            options: Default::default(),
+            source: "say '(.*)'".to_string(),
+        };
+        let input = "say 'anything'";
+
+        let matcher: Matcher = spec.try_into().unwrap();
+        if let MatchResult::Matched {
+            remaining,
+            full_match,
+            variables,
+        } = matcher.try_match(input.into())
+        {
+            assert_eq!(&remaining[..], "say 'anything'");
+            assert_eq!(&full_match[..], "say 'anything'");
+            assert_eq!(&(variables[&MatchVariable::Index(0)])[..], "say 'anything'");
+            assert_eq!(&(variables[&MatchVariable::Index(1)])[..], "anything");
+        } else {
+            panic!("Expected {:?} to match... but it didn't", matcher);
+        }
+    }
+
+    #[test]
+    fn named_matches_test() {
+        let spec = MatcherSpec::Regex {
+            options: Default::default(),
+            source: "say '(?P<message>.*)'".to_string(),
+        };
+        let input = "say 'anything'";
+
+        let matcher: Matcher = spec.try_into().unwrap();
+        if let MatchResult::Matched {
+            remaining,
+            full_match,
+            variables,
+        } = matcher.try_match(input.into())
+        {
+            assert_eq!(&remaining[..], "say 'anything'");
+            assert_eq!(&full_match[..], "say 'anything'");
+            assert_eq!(&(variables[&MatchVariable::Index(0)])[..], "say 'anything'");
+            assert_eq!(
+                &(variables[&MatchVariable::Name("message".to_string())])[..],
+                "anything"
+            );
+        } else {
+            panic!("Expected {:?} to match... but it didn't", matcher);
         }
     }
 }

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -59,7 +59,6 @@ impl Matcher {
                 };
             }
 
-            // TODO: Map pattern range back to Ansi bytes range
             let remaining = subject.clone();
             let context = self.extract_match_context(&stripped, found);
 

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -1,0 +1,22 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct MatcherOptions {
+    #[serde(default)]
+    pub consume: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum MatcherSpec {
+    Regex {
+        #[serde(flatten)]
+        options: MatcherOptions,
+        source: String,
+    },
+    Simple {
+        #[serde(flatten)]
+        options: MatcherOptions,
+        source: String,
+    },
+}

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -49,11 +49,14 @@ pub struct Matcher {
 }
 
 impl Matcher {
-    pub fn try_match(&self, subject: Ansi) -> MatchResult {
-        if let Some(found) = self.pattern.captures(&subject) {
+    pub fn try_match(&self, mut subject: Ansi) -> MatchResult {
+        let stripped = subject.strip_ansi();
+        if let Some(found) = self.pattern.captures(&stripped) {
             if self.options.consume {
                 // TODO: Consume
-                return MatchResult::Consumed { remaining: subject };
+                return MatchResult::Consumed {
+                    remaining: Ansi::empty(),
+                };
             }
 
             // TODO: Map pattern range back to Ansi bytes range
@@ -63,7 +66,6 @@ impl Matcher {
             return MatchResult::Matched { remaining, context };
         }
 
-        println!("pattern {:?} did not find", self.pattern);
         MatchResult::Ignored(subject)
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 
 use self::connections::Connections;
 
+pub mod clearable;
 pub mod connections;
 pub mod matchers;
 pub mod processing;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 use self::connections::Connections;
 
 pub mod connections;
+pub mod matchers;
+pub mod processing;
 
 pub type Id = u64;
 

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -140,14 +140,13 @@ fn strip_ansi(bytes: Bytes) -> AnsiStripped {
     for (index, ch) in raw.char_indices() {
         match (ch as u8, maybe_csi, in_csi) {
             // ESC
-            (0x1bu8, false, false) => {
+            (0x1b, false, false) => {
                 maybe_csi = true;
                 in_csi = false;
                 range_start = index;
             }
 
-            // [
-            (0x5Bu8, true, false) => {
+            (b'[', true, false) => {
                 maybe_csi = false;
                 in_csi = true;
             }

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -52,11 +52,7 @@ impl AnsiMut {
     }
 
     pub fn take_bytes(&mut self) -> BytesMut {
-        let result = self.0.clone();
-
-        self.0.clear();
-
-        return result;
+        self.0.split()
     }
 
     pub fn take(&mut self) -> Ansi {

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -1,0 +1,42 @@
+use std::ops::Deref;
+
+use bytes::{BufMut, BytesMut};
+
+#[derive(Clone, Default)]
+pub struct Ansi(BytesMut);
+
+impl Deref for Ansi {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        // TODO Strip ANSI codes
+        ""
+    }
+}
+
+impl AsRef<[u8]> for Ansi {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Into<BytesMut> for Ansi {
+    fn into(self) -> BytesMut {
+        self.0
+    }
+}
+
+impl Ansi {
+    pub fn put_slice(&mut self, bytes: &[u8]) {
+        self.0.put_slice(bytes)
+    }
+
+    pub fn take(&mut self) -> BytesMut {
+        let result = self.0.clone();
+
+        self.0.clear();
+
+        return result;
+    }
+}

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -9,8 +9,8 @@ impl Deref for Ansi {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        // TODO Strip ANSI codes
-        ""
+        // TODO strip ANSI codes
+        std::str::from_utf8(&self.0).unwrap()
     }
 }
 
@@ -27,9 +27,19 @@ impl Into<BytesMut> for Ansi {
     }
 }
 
+impl From<&str> for Ansi {
+    fn from(source: &str) -> Self {
+        Self::from_bytes(BytesMut::from(source))
+    }
+}
+
 impl Ansi {
     pub fn from_bytes(bytes: BytesMut) -> Self {
         Self(bytes)
+    }
+
+    pub fn from<T: Into<BytesMut>>(bytes: T) -> Self {
+        Self::from_bytes(bytes.into())
     }
 
     pub fn into_inner(self) -> BytesMut {

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -28,6 +28,14 @@ impl Into<BytesMut> for Ansi {
 }
 
 impl Ansi {
+    pub fn from_bytes(bytes: BytesMut) -> Self {
+        Self(bytes)
+    }
+
+    pub fn into_inner(self) -> BytesMut {
+        self.0
+    }
+
     pub fn put_slice(&mut self, bytes: &[u8]) {
         self.0.put_slice(bytes)
     }

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -88,6 +88,12 @@ impl From<&str> for Ansi {
     }
 }
 
+impl From<BytesMut> for Ansi {
+    fn from(source: BytesMut) -> Self {
+        Ansi::from_bytes(source.into())
+    }
+}
+
 impl Into<Bytes> for Ansi {
     fn into(self) -> Bytes {
         self.bytes
@@ -110,12 +116,12 @@ impl Ansi {
         Self::from_bytes(bytes.into())
     }
 
-    pub fn into_inner(self) -> Bytes {
-        self.bytes
+    pub fn as_bytes(&self) -> Bytes {
+        self.bytes.clone()
     }
 
-    pub fn iter(&self) -> std::slice::Iter<u8> {
-        self.bytes.iter()
+    pub fn into_inner(self) -> Bytes {
+        self.bytes
     }
 
     pub fn strip_ansi(&mut self) -> AnsiStripped {

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -1,39 +1,44 @@
 use std::ops::Deref;
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 
 #[derive(Clone, Default)]
-pub struct Ansi(BytesMut);
+pub struct AnsiMut(BytesMut);
 
-impl Deref for Ansi {
+impl Deref for AnsiMut {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        // TODO strip ANSI codes
         std::str::from_utf8(&self.0).unwrap()
     }
 }
 
-impl AsRef<[u8]> for Ansi {
+impl AsRef<[u8]> for AnsiMut {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl Into<BytesMut> for Ansi {
+impl Into<BytesMut> for AnsiMut {
     fn into(self) -> BytesMut {
         self.0
     }
 }
 
-impl From<&str> for Ansi {
+impl Into<Ansi> for AnsiMut {
+    fn into(self) -> Ansi {
+        Ansi::from_bytes(self.0.freeze())
+    }
+}
+
+impl From<&str> for AnsiMut {
     fn from(source: &str) -> Self {
         Self::from_bytes(BytesMut::from(source))
     }
 }
 
-impl Ansi {
+impl AnsiMut {
     pub fn from_bytes(bytes: BytesMut) -> Self {
         Self(bytes)
     }
@@ -42,19 +47,151 @@ impl Ansi {
         Self::from_bytes(bytes.into())
     }
 
-    pub fn into_inner(self) -> BytesMut {
-        self.0
-    }
-
     pub fn put_slice(&mut self, bytes: &[u8]) {
         self.0.put_slice(bytes)
     }
 
-    pub fn take(&mut self) -> BytesMut {
+    pub fn take_bytes(&mut self) -> BytesMut {
         let result = self.0.clone();
 
         self.0.clear();
 
         return result;
+    }
+
+    pub fn take(&mut self) -> Ansi {
+        let bytes = self.take_bytes();
+        Ansi::from(bytes.freeze())
+    }
+}
+
+#[derive(Clone)]
+pub struct Ansi {
+    bytes: Bytes,
+    stripped: Option<AnsiStripped>,
+}
+
+impl Deref for Ansi {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        std::str::from_utf8(&self.bytes).unwrap()
+    }
+}
+
+impl AsRef<[u8]> for Ansi {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl From<&str> for Ansi {
+    fn from(source: &str) -> Self {
+        AnsiMut::from(source).into()
+    }
+}
+
+impl Into<Bytes> for Ansi {
+    fn into(self) -> Bytes {
+        self.bytes
+    }
+}
+
+impl Ansi {
+    pub fn empty() -> Self {
+        Self::from_bytes(Bytes::default())
+    }
+
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        Self {
+            bytes,
+            stripped: None,
+        }
+    }
+
+    pub fn from<T: Into<Bytes>>(bytes: T) -> Self {
+        Self::from_bytes(bytes.into())
+    }
+
+    pub fn into_inner(self) -> Bytes {
+        self.bytes
+    }
+
+    pub fn strip_ansi(&mut self) -> AnsiStripped {
+        if let Some(existing) = self.stripped.as_ref() {
+            return existing.clone();
+        }
+
+        // TODO Use Bytes ranges from self.bytes to avoid excessive copying
+        let raw = std::str::from_utf8(&self.bytes).unwrap();
+        let mut without_ansi = String::new();
+        let mut maybe_csi = false;
+        let mut in_csi = false;
+
+        for ch in raw.chars() {
+            match (ch as u8, maybe_csi, in_csi) {
+                // ESC
+                (0x1bu8, false, false) => {
+                    maybe_csi = true;
+                    in_csi = false;
+                }
+
+                // [
+                (0x5Bu8, true, false) => {
+                    maybe_csi = false;
+                    in_csi = true;
+                }
+
+                // Detect ending
+                (as_byte, false, true) => {
+                    if (0x40..0x7E).contains(&as_byte) {
+                        in_csi = false;
+                    }
+                }
+
+                _ => {
+                    without_ansi.push(ch);
+                }
+            };
+        }
+
+        // Cache the result:
+        let stripped = AnsiStripped {
+            value: Bytes::from(without_ansi),
+        };
+        self.stripped = Some(stripped.clone());
+        return stripped;
+    }
+}
+
+#[derive(Clone)]
+pub struct AnsiStripped {
+    value: Bytes,
+    // TODO Ranges for mapping back to Ansi bytes
+}
+
+impl Deref for AnsiStripped {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        std::str::from_utf8(&self.value).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi() {
+        let mut ansi = Ansi::from("\x1b[32mColorful\x1b[m");
+        assert_eq!(&ansi.strip_ansi()[..], "Colorful");
+    }
+
+    #[test]
+    fn but_only_strip_ansi() {
+        let mut ansi = Ansi::from("say ['anything']");
+        assert_eq!(&ansi.strip_ansi()[..], "say ['anything']");
     }
 }

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -114,6 +114,10 @@ impl Ansi {
         self.bytes
     }
 
+    pub fn iter(&self) -> std::slice::Iter<u8> {
+        self.bytes.iter()
+    }
+
     pub fn strip_ansi(&mut self) -> AnsiStripped {
         if let Some(existing) = self.stripped.as_ref() {
             return existing.clone();

--- a/src/app/processing/mod.rs
+++ b/src/app/processing/mod.rs
@@ -1,0 +1,1 @@
+pub mod text;

--- a/src/app/processing/mod.rs
+++ b/src/app/processing/mod.rs
@@ -1,1 +1,2 @@
+pub mod ansi;
 pub mod text;

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -1,0 +1,34 @@
+use bytes::BytesMut;
+
+use crate::{
+    app::{matchers::MatcherSpec, Id},
+    daemon::channel::RespondedChannel,
+};
+
+struct RegisteredMatcher {
+    matcher: MatcherSpec, // TODO compiled Matcher
+    handler: Id,
+}
+
+#[derive(Default)]
+pub struct TextProcessor {
+    matchers: Vec<RegisteredMatcher>,
+}
+
+impl TextProcessor {
+    pub fn process(
+        &mut self,
+        text: BytesMut,
+        connection_id: Id,
+        notifier: &mut RespondedChannel,
+    ) -> BytesMut {
+        // TODO It might be better if we could avoid a dependency on RespondedChannel here,
+        // and emit results rather than sending them directly...
+        text
+    }
+
+    // TODO compiled Matcher
+    pub fn register(&mut self, handler: Id, matcher: MatcherSpec) {
+        self.matchers.push(RegisteredMatcher { matcher, handler })
+    }
+}

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -1,9 +1,12 @@
 use bytes::BytesMut;
+use regex::Regex;
 
 use crate::{
     app::{matchers::MatcherSpec, Id},
     daemon::channel::RespondedChannel,
 };
+
+use super::ansi::Ansi;
 
 struct RegisteredMatcher {
     matcher: MatcherSpec, // TODO compiled Matcher
@@ -13,6 +16,7 @@ struct RegisteredMatcher {
 #[derive(Default)]
 pub struct TextProcessor {
     matchers: Vec<RegisteredMatcher>,
+    pending_line: Ansi,
 }
 
 impl TextProcessor {
@@ -22,9 +26,21 @@ impl TextProcessor {
         connection_id: Id,
         notifier: &mut RespondedChannel,
     ) -> BytesMut {
+        // TODO: Read up until a newline from text; push that onto pending_line
+        // TODO: If we *don't* have a full line (and, if we don't already have a SavePosition set, IE from
+        // a previous partial line, emit SavePosition) emit the pending
+        // TODO: If we *do* have a full line in pending_Line, pop it off and feed it to matchers;
+        // if none "consume" the input, emit. If *any* consume, and we have a SavePosition set,
+        // emit RestorePosition + Clear(ClearType::UntilNewLine)
+        self.pending_line.put_slice(&text);
+        Regex::new("foo")
+            .unwrap()
+            .find(&self.pending_line)
+            .expect("hi");
+
         // TODO It might be better if we could avoid a dependency on RespondedChannel here,
         // and emit results rather than sending them directly...
-        text
+        self.pending_line.take()
     }
 
     // TODO compiled Matcher

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -33,17 +33,18 @@ pub struct TextProcessor {
 impl TextProcessor {
     pub fn process(
         &mut self,
-        text: BytesMut,
+        text: Ansi,
         _connection_id: Id, // TODO
         notifier: &mut RespondedChannel,
     ) -> Bytes {
         // Read up until a newline from text; push that onto pending_line
         let has_full_line =
             if let Some(newline_pos) = text.iter().position(|ch| *ch == NEWLINE_BYTE) {
-                self.pending_line.put_slice(&text[0..newline_pos]);
+                self.pending_line
+                    .put_slice(&text.into_inner()[0..newline_pos]);
                 true
             } else {
-                self.pending_line.put_slice(&text);
+                self.pending_line.put_slice(&text.into_inner());
                 false
             };
 

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -1,12 +1,21 @@
-use bytes::BytesMut;
-use regex::Regex;
+use bytes::{BufMut, BytesMut};
+use crossterm::{
+    cursor::{RestorePosition, SavePosition},
+    execute,
+    terminal::{Clear, ClearType},
+};
 
 use crate::{
-    app::{matchers::MatcherSpec, Id},
+    app::{
+        matchers::{MatchResult, MatcherSpec},
+        Id,
+    },
     daemon::channel::RespondedChannel,
 };
 
 use super::ansi::Ansi;
+
+const NEWLINE_BYTE: u8 = b'\n';
 
 struct RegisteredMatcher {
     matcher: MatcherSpec, // TODO compiled Matcher
@@ -17,34 +26,77 @@ struct RegisteredMatcher {
 pub struct TextProcessor {
     matchers: Vec<RegisteredMatcher>,
     pending_line: Ansi,
+    saving_position: bool,
 }
 
 impl TextProcessor {
     pub fn process(
         &mut self,
         text: BytesMut,
-        connection_id: Id,
-        notifier: &mut RespondedChannel,
+        _connection_id: Id, // TODO
+        _notifier: &mut RespondedChannel,
     ) -> BytesMut {
         // TODO: Read up until a newline from text; push that onto pending_line
-        // TODO: If we *don't* have a full line (and, if we don't already have a SavePosition set, IE from
-        // a previous partial line, emit SavePosition) emit the pending
-        // TODO: If we *do* have a full line in pending_Line, pop it off and feed it to matchers;
-        // if none "consume" the input, emit. If *any* consume, and we have a SavePosition set,
-        // emit RestorePosition + Clear(ClearType::UntilNewLine)
-        self.pending_line.put_slice(&text);
-        Regex::new("foo")
-            .unwrap()
-            .find(&self.pending_line)
-            .expect("hi");
+        let has_full_line =
+            if let Some(newline_pos) = text.iter().position(|ch| *ch == NEWLINE_BYTE) {
+                self.pending_line.put_slice(&text[0..newline_pos]);
+                true
+            } else {
+                self.pending_line.put_slice(&text);
+                false
+            };
 
-        // TODO It might be better if we could avoid a dependency on RespondedChannel here,
-        // and emit results rather than sending them directly...
-        self.pending_line.take()
+        let result = if !has_full_line {
+            // If we *don't* have a full line (and, if we don't already have a SavePosition
+            // set, IE from a previous partial line, emit SavePosition) emit the pending
+            let mut to_emit = BytesMut::with_capacity(self.pending_line.len() + 8);
+            if !self.saving_position {
+                self.saving_position = true;
+
+                let mut writer = to_emit.writer();
+                execute!(writer, SavePosition).expect("Failed to write ansi");
+                to_emit = writer.into_inner();
+            }
+            to_emit.put(self.pending_line.take());
+            to_emit
+        } else {
+            // If we *do* have a full line in pending_line, pop it off and feed it to matchers;
+            // if none "consume" the input, emit. If *any* consume, and we have a SavePosition set,
+            // emit RestorePosition + Clear
+            let to_match = self.pending_line.take();
+
+            // TODO It might be better if we could avoid a dependency on RespondedChannel here, and
+            // emit results rather than sending them directly...
+            match self.perform_match(Ansi::from_bytes(to_match)) {
+                MatchResult::Ignored(to_emit) => to_emit.into(),
+                MatchResult::Consumed { remaining } => {
+                    if self.saving_position {
+                        self.saving_position = false;
+
+                        let mut to_emit = BytesMut::with_capacity(remaining.len() + 8);
+                        let mut writer = to_emit.writer();
+                        execute!(writer, RestorePosition, Clear(ClearType::FromCursorDown))
+                            .expect("Failed to write ansi");
+                        to_emit = writer.into_inner();
+                        to_emit.put(remaining.into_inner());
+                        to_emit.into()
+                    } else {
+                        remaining.into()
+                    }
+                }
+            }
+        };
+
+        return result;
     }
 
     // TODO compiled Matcher
     pub fn register(&mut self, handler: Id, matcher: MatcherSpec) {
         self.matchers.push(RegisteredMatcher { matcher, handler })
+    }
+
+    fn perform_match(&mut self, mut to_match: Ansi) -> MatchResult {
+        // TODO: Do The Thing.
+        MatchResult::Ignored(to_match)
     }
 }

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -36,7 +36,7 @@ impl TextProcessor {
         _connection_id: Id, // TODO
         _notifier: &mut RespondedChannel,
     ) -> BytesMut {
-        // TODO: Read up until a newline from text; push that onto pending_line
+        // Read up until a newline from text; push that onto pending_line
         let has_full_line =
             if let Some(newline_pos) = text.iter().position(|ch| *ch == NEWLINE_BYTE) {
                 self.pending_line.put_slice(&text[0..newline_pos]);

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -85,10 +85,9 @@ impl TextProcessor {
                     }
                 }
 
-                MatchResult::Matched { remaining, .. } => {
+                MatchResult::Matched { remaining, context } => {
                     if let Some(handler) = handler {
-                        // TODO include variables
-                        notifier.notify(DaemonNotification::TriggerMatched { handler });
+                        notifier.notify(DaemonNotification::TriggerMatched { handler, context });
                     }
 
                     remaining.into()

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -6,6 +6,7 @@ use crossterm::{
 
 use crate::{
     app::{
+        clearable::Clearable,
         matchers::{MatchResult, Matcher},
         Id,
     },
@@ -103,6 +104,12 @@ impl TextProcessor {
         }
 
         return MatchResult::Ignored(to_match);
+    }
+}
+
+impl Clearable for TextProcessor {
+    fn clear(&mut self) {
+        self.matchers.clear();
     }
 }
 

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -82,6 +82,10 @@ impl TextProcessor {
                         remaining.into()
                     }
                 }
+
+                MatchResult::Matched { .. } => {
+                    todo!();
+                }
             }
         };
 

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -98,9 +98,12 @@ impl TextProcessor {
                 }
 
                 MatchResult::Matched { remaining, context } => {
-                    if let Some(handler) = handler {
+                    if let Some(handler_id) = handler {
                         output_chunks.push(ProcessorOutput::Notification(
-                            DaemonNotification::TriggerMatched { handler, context },
+                            DaemonNotification::TriggerMatched {
+                                handler_id,
+                                context,
+                            },
                         ))
                     }
 

--- a/src/daemon/channel.rs
+++ b/src/daemon/channel.rs
@@ -5,7 +5,10 @@ use std::{
 
 use serde::Serialize;
 
-use super::{notifications::DaemonNotification, protocol::Response, responses::DaemonResponse};
+use super::{
+    protocol::{Notification, Response},
+    responses::DaemonResponse,
+};
 
 #[derive(Clone)]
 struct LockedWriter(Arc<Mutex<Box<dyn Write + Send>>>, Arc<Mutex<()>>);
@@ -39,7 +42,7 @@ pub struct Channel {
 
 impl Channel {
     #[allow(dead_code)]
-    pub fn notify(&mut self, payload: DaemonNotification) {
+    pub fn notify(&mut self, payload: Notification) {
         self.writer.write_json(&payload).unwrap();
     }
 
@@ -62,7 +65,7 @@ pub struct RespondedChannel {
 }
 
 impl RespondedChannel {
-    pub fn notify(&mut self, payload: DaemonNotification) {
+    pub fn notify(&mut self, payload: Notification) {
         self.writer.write_json(&payload).unwrap();
     }
 }

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -9,9 +9,7 @@ pub struct Connect {
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
-pub enum DaemonCommand {
-    Quit,
-
+pub enum ClientRequest {
     Connect(Connect),
     Disconnect {
         connection_id: Id,
@@ -21,12 +19,17 @@ pub enum DaemonCommand {
         text: String,
     },
 
-    Clear {
-        connection: Id,
-    },
     RegisterTrigger {
         connection_id: Id,
         matcher: MatcherSpec,
         handler_id: Id,
     },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum ClientNotification {
+    Quit,
+
+    Clear { connection_id: Id },
 }

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -14,10 +14,10 @@ pub enum DaemonCommand {
 
     Connect(Connect),
     Disconnect {
-        connection: Id,
+        connection_id: Id,
     },
     Send {
-        connection: Id,
+        connection_id: Id,
         text: String,
     },
 
@@ -25,7 +25,7 @@ pub enum DaemonCommand {
         connection: Id,
     },
     RegisterTrigger {
-        connection: Id,
+        connection_id: Id,
         matcher: MatcherSpec,
         handler_id: Id,
     },

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::app::Id;
+use crate::app::{matchers::MatcherSpec, Id};
 
 #[derive(Debug, Deserialize)]
 pub struct Connect {
@@ -13,6 +13,20 @@ pub enum DaemonCommand {
     Quit,
 
     Connect(Connect),
-    Disconnect { connection: Id },
-    Send { connection: Id, text: String },
+    Disconnect {
+        connection: Id,
+    },
+    Send {
+        connection: Id,
+        text: String,
+    },
+
+    Clear {
+        connection: Id,
+    },
+    RegisterTrigger {
+        connection: Id,
+        matcher: MatcherSpec,
+        handler_id: Id,
+    },
 }

--- a/src/daemon/handlers/clear.rs
+++ b/src/daemon/handlers/clear.rs
@@ -1,0 +1,12 @@
+use crate::app::{clearable::Clearable, Id, LockableState};
+
+pub async fn handle(mut state: LockableState, connection_id: Id) {
+    let connection_ref =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            return;
+        };
+    let mut connection = connection_ref.lock().unwrap();
+    connection.processor.clear();
+}

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::{
     app::{
         connections::{ConnectionReceiver, Outgoing},
+        processing::ansi::Ansi,
         LockableState,
     },
     daemon::{
@@ -29,9 +30,9 @@ pub fn process_connection<T: Transport, W: Write>(
         match transport.read()? {
             Event::Data(data) => {
                 let r: &[u8] = &data;
-                let wrapped = BytesMut::from(r);
+                let bytes = BytesMut::from(r);
                 let processed = connection.shared_state.lock().unwrap().processor.process(
-                    wrapped,
+                    Ansi::from(bytes.freeze()),
                     connection.id,
                     &mut notifier,
                 );

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod clear;
 pub mod connect;
 pub mod disconnect;
 pub mod register_trigger;

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod connect;
 pub mod disconnect;
+pub mod register_trigger;
 pub mod send;

--- a/src/daemon/handlers/register_trigger.rs
+++ b/src/daemon/handlers/register_trigger.rs
@@ -1,0 +1,17 @@
+use crate::app::{matchers::MatcherSpec, Id, LockableState};
+
+pub async fn handle(
+    mut state: LockableState,
+    connection_id: Id,
+    matcher: MatcherSpec,
+    handler_id: Id,
+) {
+    let connection_ref =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            return;
+        };
+    let mut connection = connection_ref.lock().unwrap();
+    connection.processor.register(handler_id, matcher);
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -6,7 +6,7 @@ use std::{
 pub mod channel;
 mod commands;
 mod handlers;
-mod notifications;
+pub mod notifications;
 mod protocol;
 mod responses;
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -46,10 +46,15 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
             DaemonCommand::Connect(data) => {
                 launch(handlers::connect::handle(channel, state, data));
             }
-            DaemonCommand::Disconnect { connection } => {
+            DaemonCommand::Disconnect {
+                connection_id: connection,
+            } => {
                 tokio::spawn(handlers::disconnect::handle(state, connection));
             }
-            DaemonCommand::Send { connection, text } => {
+            DaemonCommand::Send {
+                connection_id: connection,
+                text,
+            } => {
                 tokio::spawn(handlers::send::handle(channel, state, connection, text));
             }
 
@@ -58,7 +63,7 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
             }
 
             DaemonCommand::RegisterTrigger {
-                connection,
+                connection_id: connection,
                 matcher,
                 handler_id,
             } => {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -54,7 +54,7 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
             }
 
             DaemonCommand::Clear { connection } => {
-                // TODO
+                tokio::spawn(handlers::clear::handle(state, connection));
             }
 
             DaemonCommand::RegisterTrigger {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, BufRead, Write},
 };
 
-mod channel;
+pub mod channel;
 mod commands;
 mod handlers;
 mod notifications;
@@ -51,6 +51,20 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
             }
             DaemonCommand::Send { connection, text } => {
                 tokio::spawn(handlers::send::handle(channel, state, connection, text));
+            }
+
+            DaemonCommand::Clear { connection } => {
+                // TODO
+            }
+
+            DaemonCommand::RegisterTrigger {
+                connection,
+                matcher,
+                handler_id,
+            } => {
+                tokio::spawn(handlers::register_trigger::handle(
+                    state, connection, matcher, handler_id,
+                ));
             }
         };
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -63,7 +63,7 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
                 handler_id,
             } => {
                 tokio::spawn(handlers::register_trigger::handle(
-                    state, connection, matcher, handler_id,
+                    channel, state, connection, matcher, handler_id,
                 ));
             }
         };

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -8,7 +8,7 @@ mod commands;
 mod handlers;
 pub mod notifications;
 mod protocol;
-mod responses;
+pub mod responses;
 
 use commands::DaemonCommand;
 

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -1,11 +1,36 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 
-use crate::app::Id;
+use crate::app::{processing::ansi::Ansi, Id};
+
+#[derive(Serialize)]
+pub struct MatchedText {
+    pub plain: String,
+    pub ansi: String,
+}
+impl MatchedText {
+    pub fn from_raw_ansi(text: &str) -> Self {
+        let as_ansi = Ansi::from(text);
+        return MatchedText {
+            plain: (&as_ansi).to_string(),
+            ansi: std::str::from_utf8(&as_ansi.into_inner())
+                .unwrap()
+                .to_string(),
+        };
+    }
+}
+
+#[derive(Serialize)]
+pub struct MatchContext {
+    pub named: HashMap<String, MatchedText>,
+    pub indexed: HashMap<usize, MatchedText>,
+}
 
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum DaemonNotification {
     Connected { id: Id },
     Disconnected { id: Id },
-    TriggerMatched { handler: Id },
+    TriggerMatched { handler: Id, context: MatchContext },
 }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -28,7 +28,10 @@ pub struct MatchContext {
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum DaemonNotification {
-    Connected { id: Id },
-    Disconnected { id: Id },
-    TriggerMatched { handler: Id, context: MatchContext },
+    Connected,
+    Disconnected,
+    TriggerMatched {
+        handler_id: Id,
+        context: MatchContext,
+    },
 }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -9,12 +9,12 @@ pub struct MatchedText {
     pub plain: String,
     pub ansi: String,
 }
+
 impl MatchedText {
-    pub fn from_raw_ansi(text: &str) -> Self {
-        let mut as_ansi: Ansi = text.into();
+    pub fn from(mut ansi: Ansi) -> Self {
         return MatchedText {
-            ansi: (&as_ansi).to_string(),
-            plain: as_ansi.strip_ansi().to_string(),
+            ansi: (&ansi).to_string(),
+            plain: ansi.strip_ansi().to_string(),
         };
     }
 }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -7,4 +7,5 @@ use crate::app::Id;
 pub enum DaemonNotification {
     Connected { id: Id },
     Disconnected { id: Id },
+    TriggerMatched { handler: Id },
 }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -11,12 +11,10 @@ pub struct MatchedText {
 }
 impl MatchedText {
     pub fn from_raw_ansi(text: &str) -> Self {
-        let as_ansi = Ansi::from(text);
+        let mut as_ansi: Ansi = text.into();
         return MatchedText {
-            plain: (&as_ansi).to_string(),
-            ansi: std::str::from_utf8(&as_ansi.into_inner())
-                .unwrap()
-                .to_string(),
+            ansi: (&as_ansi).to_string(),
+            plain: as_ansi.strip_ansi().to_string(),
         };
     }
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use super::{commands::DaemonCommand, responses::DaemonResponse};
+use crate::app::Id;
+
+use super::{
+    commands::DaemonCommand, notifications::DaemonNotification, responses::DaemonResponse,
+};
 
 #[derive(Deserialize)]
 pub struct Request {
@@ -16,4 +20,30 @@ pub struct Response {
 
     #[serde(flatten)]
     pub payload: DaemonResponse,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum Notification {
+    ForConnection {
+        connection_id: Id,
+
+        #[serde(flatten)]
+        notification: DaemonNotification,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization_test() {
+        let s = serde_json::to_string(&Notification::ForConnection {
+            connection_id: 42,
+            notification: DaemonNotification::Connected,
+        })
+        .unwrap();
+        assert_eq!(s, r#"{"connection_id":42,"type":"Connected"}"#);
+    }
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -3,15 +3,22 @@ use serde::{Deserialize, Serialize};
 use crate::app::Id;
 
 use super::{
-    commands::DaemonCommand, notifications::DaemonNotification, responses::DaemonResponse,
+    commands::{ClientNotification, ClientRequest},
+    notifications::DaemonNotification,
+    responses::DaemonResponse,
 };
 
 #[derive(Deserialize)]
-pub struct Request {
-    pub id: u64,
+#[serde(untagged)]
+pub enum Request {
+    ForResponse {
+        id: u64,
 
-    #[serde(flatten)]
-    pub payload: DaemonCommand,
+        #[serde(flatten)]
+        payload: ClientRequest,
+    },
+
+    Notification(ClientNotification),
 }
 
 #[derive(Serialize)]
@@ -45,5 +52,27 @@ mod tests {
         })
         .unwrap();
         assert_eq!(s, r#"{"connection_id":42,"type":"Connected"}"#);
+    }
+
+    #[test]
+    fn request_deserialization_test() {
+        let mut r: Request = serde_json::from_str(r#"{"type":"Quit"}"#).unwrap();
+        match r {
+            Request::Notification(ClientNotification::Quit) => {}
+            _ => assert!(false, "Expected Quit Notification"),
+        }
+
+        r = serde_json::from_str(r#"{"id": 9001, "type":"Disconnect", "connection_id": 42}"#)
+            .unwrap();
+        match r {
+            Request::ForResponse {
+                id,
+                payload: ClientRequest::Disconnect { connection_id },
+            } => {
+                assert_eq!(id, 9001);
+                assert_eq!(connection_id, 42);
+            }
+            _ => assert!(false, "Expected Disconnect Rquest"),
+        }
     }
 }

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -5,6 +5,8 @@ use crate::app::Id;
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum DaemonResponse {
+    ErrorResult { error: String },
+
     Connecting { id: Id },
     SendResult { sent: bool },
 }

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -7,6 +7,6 @@ use crate::app::Id;
 pub enum DaemonResponse {
     ErrorResult { error: String },
 
-    Connecting { id: Id },
+    Connecting { connection_id: Id },
     SendResult { sent: bool },
 }


### PR DESCRIPTION
Included is a whole ton of refactoring and cleanup!

In particular, Ansi text is no longer assumed to deference directly to ansi-stripped &str, but instead stripping Ansi sequences must be explicitly requested. This process enables us to map back from ranges in the Ansi-stripped string back to ranges in the original Ansi string. We additionally separate a mutable AnsiMut from the immutable Ansi, similar to the distinction between Bytes and BytesMut.

- Prepare lua API for declaring triggers
- Receive TriggerFired events
- Fix: not filtering by connection_id
- Notify daemon that we're "clearing" state
- Update MatcherSpec types to ensure rust casing
- Scaffold out rust handling of Matchers/TextProcessors
- Prepare logic and utilities for handling Triggers
- Implement core trigger processing logic
- Clean up accomplished TODO
- Introduce a macro to simplify ansi writing
- Scaffold matcher "compilation" step + basic match checking
- Implement Clear command
- Add basic match extraction
- Scaffold out trigger match notification
- Refactor match context storage to be serializable; return to client
- Refactor Ansi to abandon notion of deref'ing into ansi-stripped
- Use split() to make take_bytes() more efficient
- Add basic support for mapping ranges from AnsiStripped back to Ansi
- Clean up resolved TODO
- Use a byte literal for readability
- Pass Ansi to TextProcessor
- Fix hang caused by incomplete processing
- Clean up and unify IDs, etc. Triggers work!!
- Rename Request.connection -> connection_id
- Refactor with explicit Request/Notification client event types
