### PR TITLE
Add support for Prompts

### DIFF
--- a/lua/kodachi/handlers.lua
+++ b/lua/kodachi/handlers.lua
@@ -19,6 +19,10 @@ function Handlers:clear()
   self._next_id = 0
 end
 
+function Handlers:allocate_id()
+  return self:insert(nil)
+end
+
 function Handlers:insert(handler)
   local id = self._next_id
   self._next_id = id + 1
@@ -32,6 +36,10 @@ end
 
 function Handlers:get(id)
   return self._entries[id]
+end
+
+function Handlers:put(id, handler)
+  self._entries[id] = handler
 end
 
 return Handlers

--- a/lua/kodachi/matchers.lua
+++ b/lua/kodachi/matchers.lua
@@ -17,11 +17,16 @@ end
 ---Create a matcher using the regex syntax of the Rust lang `regex` library
 ---@param pattern string A perl-like regex pattern.
 ---@return MatcherSpec
-function M.regex(pattern)
+function M.regex(pattern, options)
   return {
     type = 'Regex',
     source = pattern,
+    consume = options and options.consume,
   }
+end
+
+function M.re_consume(pattern)
+  return M.regex(pattern, { consume = true })
 end
 
 ---Create a matcher using "simple" syntax
@@ -33,6 +38,5 @@ function M.simple(pattern)
     source = pattern,
   }
 end
-
 
 return M

--- a/lua/kodachi/prompts.lua
+++ b/lua/kodachi/prompts.lua
@@ -1,0 +1,95 @@
+local Handlers = require 'kodachi.handlers'
+local matchers = require 'kodachi.matchers'
+
+local util = require 'kodachi.util.state'
+local with_socket = util.with_socket
+
+---@class PromptGroup
+---@field group_id number
+---@field state KodachiState
+---@field _prompts Handlers
+local PromptGroup = {}
+
+function PromptGroup:new(id, state)
+  local o = {
+    group_id = id,
+    state = state,
+    _prompts = Handlers:new()
+  }
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+---@param matcher MatcherSpec|string
+---@param handler fun(context)|nil If provided, a fn called with the same params as a trigger() handler,
+---and whose return value will be used as the prompt content
+function PromptGroup:add(matcher, handler)
+  matcher = matchers.inflate(matcher)
+
+  local prompt_index = self._prompts:allocate_id()
+
+  return with_socket(self.state, function(socket)
+    if not handler then
+      socket:request {
+        type = "RegisterPrompt",
+        connection_id = self.state.connection_id,
+        matcher = matcher,
+        group_id = self.group_id,
+        prompt_index = prompt_index,
+      }
+      return
+    end
+
+    self.state:trigger(matcher, function(context)
+      local to_render = handler(context)
+      if to_render then
+        socket:request {
+          type = "SetPromptContent",
+          connection_id = self.state.connection_id,
+          group_id = self.group_id,
+          prompt_index = prompt_index,
+          content = to_render,
+        }
+      end
+    end)
+  end)
+end
+
+---@class PromptsManager
+---@field _groups Handlers
+---@field state KodachiState
+local PromptsManager = {}
+
+function PromptsManager:new(state)
+  local o = {
+    state = state,
+    _groups = Handlers:new()
+  }
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function PromptsManager:clear()
+  self._groups:clear()
+end
+
+function PromptsManager:create_group()
+  local group_id = self._groups:allocate_id()
+  return self:group(group_id)
+end
+
+---@return PromptGroup
+function PromptsManager:group(id)
+  local existing = self._groups:get(id)
+  if existing then
+    return existing
+  end
+
+  local group = PromptGroup:new(id, self.state)
+  self._groups:put(id, group)
+  return group
+end
+
+return PromptsManager

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -1,5 +1,9 @@
 ---@alias KodachiRequest { type: string }
 
+---@alias TriggerMatchedNotification { type: "'TriggerMatched'", connection_id: number, handler_id: number, context: table }
+---@alias DisconnectedNotification { type: "'Disconnected'", connection_id: number  }
+---@alias KodachiNotification TriggerMatchedNotification | DisconnectedNotification
+
 ---@class Socket
 ---@field name string
 ---@field _receivers any[]
@@ -22,7 +26,7 @@ function Socket:new(name, from_app, to_app)
   return o
 end
 
----@param handler fun(message:KodachiRequest)
+---@param handler fun(message:KodachiNotification)
 function Socket:listen(handler)
   table.insert(self._receivers, handler)
 end

--- a/lua/kodachi/util/state.lua
+++ b/lua/kodachi/util/state.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+---@param state KodachiState
+---@param handler fun(socket:Socket)
+function M.with_socket(state, handler)
+  if not state.connection_id then
+    return false
+  end
+
+  return handler(state.socket)
+end
+
+return M

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -85,14 +85,6 @@ impl Connections {
         }
     }
 
-    pub fn get_ui_state(&mut self, id: Id) -> Option<Arc<Mutex<UiState>>> {
-        if let Some(conn) = self.connections.get(&id) {
-            Some(conn.state.ui_state.clone())
-        } else {
-            None
-        }
-    }
-
     fn allocate_id(&mut self) -> Id {
         let id = self.next_id;
         self.next_id += 1;

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -62,7 +62,7 @@ impl Matcher {
 
             // If we consumed the whole line, drop any newlines
             if self.options.consume && remaining.trim().is_empty() {
-                remaining = Ansi::from("");
+                remaining = Ansi::empty();
             }
 
             return MatchResult::Matched {

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -70,6 +70,18 @@ pub struct Ansi {
     stripped: Option<AnsiStripped>,
 }
 
+impl Debug for Ansi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.bytes.fmt(f)
+    }
+}
+
+impl PartialEq for Ansi {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes.eq(&other.bytes)
+    }
+}
+
 impl Deref for Ansi {
     type Target = str;
 

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -133,6 +133,10 @@ impl Add for Ansi {
 }
 
 impl Ansi {
+    pub fn empty() -> Self {
+        Self::from("")
+    }
+
     pub fn from_bytes(bytes: Bytes) -> Self {
         Self {
             bytes,

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1,4 +1,4 @@
-mod prompts;
+pub mod prompts;
 
 use crossterm::{
     cursor::{MoveTo, MoveToNextLine, RestorePosition, SavePosition},
@@ -20,16 +20,19 @@ use crate::{
     },
 };
 
-use self::prompts::PromptsState;
+use self::prompts::{PromptGroups, PromptsState};
 
 #[derive(Default)]
 pub struct UiState {
     pub prompts: PromptsState,
+    pub active_prompt_group: Id,
+    pub inactive_prompt_groups: PromptGroups,
 }
 
 impl Clearable for UiState {
     fn clear(&mut self) {
         self.prompts.clear();
+        self.inactive_prompt_groups.clear();
     }
 }
 

--- a/src/cli/ui/prompts.rs
+++ b/src/cli/ui/prompts.rs
@@ -1,0 +1,60 @@
+use crate::app::{clearable::Clearable, processing::ansi::Ansi};
+
+#[derive(Default)]
+pub struct PromptsState {
+    values: Vec<Option<Ansi>>,
+}
+
+impl Clearable for PromptsState {
+    fn clear(&mut self) {
+        self.values.clear();
+    }
+}
+
+impl PromptsState {
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<Option<Ansi>> {
+        self.values.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[allow(dead_code)]
+    pub fn get(&self, index: usize) -> Option<&Ansi> {
+        self.values.get(index).map_or(None, |v| v.as_ref())
+    }
+
+    pub fn set_index(&mut self, index: usize, content: Ansi) {
+        while self.values.len() <= index {
+            self.values.push(None);
+        }
+        self.values[index] = Some(content);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_index_first() {
+        let mut state = PromptsState::default();
+        state.set_index(0, Ansi::from("grayskull"));
+        assert_eq!(state.len(), 1);
+    }
+
+    #[test]
+    fn set_after_first() {
+        let mut state = PromptsState::default();
+        state.set_index(2, Ansi::from("grayskull"));
+        assert_eq!(state.len(), 3);
+        assert_eq!(state.get(0), None);
+        assert_eq!(state.get(1), None);
+        assert_eq!(state.get(2), Some(&Ansi::from("grayskull")));
+    }
+}

--- a/src/cli/ui/prompts.rs
+++ b/src/cli/ui/prompts.rs
@@ -1,4 +1,6 @@
-use crate::app::{clearable::Clearable, processing::ansi::Ansi};
+use std::collections::HashMap;
+
+use crate::app::{clearable::Clearable, processing::ansi::Ansi, Id};
 
 #[derive(Default)]
 pub struct PromptsState {
@@ -34,6 +36,31 @@ impl PromptsState {
             self.values.push(None);
         }
         self.values[index] = Some(content);
+    }
+}
+
+#[derive(Default)]
+pub struct PromptGroups {
+    groups: HashMap<Id, PromptsState>,
+}
+
+impl Clearable for PromptGroups {
+    fn clear(&mut self) {
+        self.groups.clear();
+    }
+}
+
+impl PromptGroups {
+    pub fn get_mut(&mut self, group_id: Id) -> Option<&mut PromptsState> {
+        self.groups.get_mut(&group_id)
+    }
+
+    pub fn insert(&mut self, group_id: Id, group: PromptsState) {
+        self.groups.insert(group_id, group);
+    }
+
+    pub fn remove(&mut self, group_id: Id) -> Option<PromptsState> {
+        self.groups.remove(&group_id)
     }
 }
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -24,6 +24,39 @@ pub enum ClientRequest {
         matcher: MatcherSpec,
         handler_id: Id,
     },
+
+    /// This is provided as a convenience for declaring a Prompt line that directly renders
+    /// the whole matched line, without modification. For advanced use cases, like extracting
+    /// matched groups and rendering those, use [RegisterTrigger] with a consuming Matcher
+    /// and [SetPromptContent]
+    RegisterPrompt {
+        connection_id: Id,
+        matcher: MatcherSpec,
+        group_id: Id,
+        prompt_index: usize,
+    },
+
+    // Set the content of a Prompt line. A Prompt line is uniquely identified by the tuple
+    // (connection_id, group_id, prompt_index). `group_id` may be any arbitrary unsigned integer;
+    // `0` is a good default value. `prompt_index` is similarly any unsigned integer, but clients
+    // should prefer sequential numbers starting from `0`.
+    // Prompt lines are organized into groups to facilitate multi-line prompts, and switching
+    // between prompts based on whichever one is most-recently triggered.
+    // If `set_group_active` is true or not provided, the group_id provided here will also be made
+    // the active (displayed) prompt group.
+    SetPromptContent {
+        connection_id: Id,
+        group_id: Id,
+        prompt_index: usize,
+        content: String,
+        set_group_active: Option<bool>,
+    },
+
+    // May be used to switch the active prompt group without changing any content.
+    SetActivePromptGroup {
+        connection_id: Id,
+        group_id: Id,
+    },
 }
 
 #[derive(Deserialize)]

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -1,5 +1,8 @@
 pub mod clear;
 pub mod connect;
 pub mod disconnect;
+pub mod register_prompt;
 pub mod register_trigger;
 pub mod send;
+pub mod set_active_prompt_group;
+pub mod set_prompt_content;

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -1,0 +1,54 @@
+use crate::{
+    app::{matchers::MatcherSpec, Id, LockableState},
+    daemon::{channel::Channel, responses::DaemonResponse},
+};
+
+use super::set_prompt_content;
+
+pub async fn handle(
+    channel: Channel,
+    mut state: LockableState,
+    connection_id: Id,
+    matcher: MatcherSpec,
+    group_id: Id,
+    prompt_index: usize,
+) {
+    let processor_ref = if let Some(reference) = state
+        .lock()
+        .unwrap()
+        .connections
+        .get_processor(connection_id)
+    {
+        reference.clone()
+    } else {
+        channel.respond(DaemonResponse::OkResult);
+        return;
+    };
+
+    let compiled = match matcher.try_into() {
+        Ok(compiled) => compiled,
+        Err(e) => {
+            channel.respond(DaemonResponse::ErrorResult {
+                error: format!("{:?}", e).to_string(),
+            });
+            return;
+        }
+    };
+
+    processor_ref
+        .lock()
+        .unwrap()
+        .register(Id::MAX, compiled, move |mut context, _| {
+            set_prompt_content::try_handle(
+                state.clone(),
+                connection_id,
+                group_id,
+                prompt_index,
+                context.take_full_match().ansi,
+                true,
+            )?;
+            Ok(())
+        });
+
+    channel.respond(DaemonResponse::OkResult);
+}

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{matchers::MatcherSpec, Id, LockableState},
+    app::{matchers::MatcherSpec, processing::text::MatcherId, Id, LockableState},
     daemon::{channel::Channel, responses::DaemonResponse},
 };
 
@@ -35,11 +35,15 @@ pub async fn handle(
         }
     };
 
-    // FIXME: handler ID
+    let id = MatcherId::Prompt {
+        group: group_id,
+        index: prompt_index,
+    };
+
     processor_ref
         .lock()
         .unwrap()
-        .register(Id::MAX, compiled, move |mut context, _| {
+        .register(id, compiled, move |mut context, _| {
             set_prompt_content::try_handle(
                 state.clone(),
                 connection_id,

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -35,6 +35,7 @@ pub async fn handle(
         }
     };
 
+    // FIXME: handler ID
     processor_ref
         .lock()
         .unwrap()

--- a/src/daemon/handlers/register_trigger.rs
+++ b/src/daemon/handlers/register_trigger.rs
@@ -14,6 +14,7 @@ pub async fn handle(
         if let Some(reference) = state.lock().unwrap().connections.get_processor(connection_id) {
             reference.clone()
         } else {
+            channel.respond(DaemonResponse::OkResult);
             return;
         };
 
@@ -38,4 +39,6 @@ pub async fn handle(
                 },
             )
         });
+
+    channel.respond(DaemonResponse::OkResult);
 }

--- a/src/daemon/handlers/set_active_prompt_group.rs
+++ b/src/daemon/handlers/set_active_prompt_group.rs
@@ -1,0 +1,30 @@
+use std::io;
+
+use crate::{
+    app::{Id, LockableState},
+    daemon::{channel::Channel, responses::DaemonResponse},
+};
+
+pub async fn handle(channel: Channel, state: LockableState, connection_id: Id, group_id: Id) {
+    match try_handle(state, connection_id, group_id) {
+        Ok(_) => channel.respond(DaemonResponse::OkResult),
+        Err(e) => channel.respond(DaemonResponse::ErrorResult {
+            error: e.to_string(),
+        }),
+    };
+}
+
+pub fn try_handle(mut state: LockableState, connection_id: Id, group_id: Id) -> io::Result<()> {
+    let conn_state =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            return Ok(());
+        };
+
+    if let Ok(mut ui_state) = conn_state.ui_state.lock() {
+        // TODO set active group
+    }
+
+    Ok(())
+}

--- a/src/daemon/handlers/set_prompt_content.rs
+++ b/src/daemon/handlers/set_prompt_content.rs
@@ -1,0 +1,58 @@
+use std::io;
+
+use crate::{
+    app::{processing::ansi::Ansi, Id, LockableState},
+    daemon::{channel::Channel, responses::DaemonResponse},
+};
+
+use super::set_active_prompt_group;
+
+pub async fn handle(
+    channel: Channel,
+    state: LockableState,
+    connection_id: Id,
+    group_id: Id,
+    prompt_index: usize,
+    content: String,
+    set_group_active: bool,
+) {
+    match try_handle(
+        state,
+        connection_id,
+        group_id,
+        prompt_index,
+        content,
+        set_group_active,
+    ) {
+        Ok(_) => channel.respond(DaemonResponse::OkResult),
+        Err(e) => channel.respond(DaemonResponse::ErrorResult {
+            error: e.to_string(),
+        }),
+    };
+}
+
+pub fn try_handle(
+    mut state: LockableState,
+    connection_id: Id,
+    group_id: Id,
+    prompt_index: usize,
+    content: String,
+    set_group_active: bool,
+) -> io::Result<()> {
+    let conn_state =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            return Ok(());
+        };
+
+    if let Ok(mut ui_state) = conn_state.ui_state.lock() {
+        ui_state.prompts.insert(prompt_index, Ansi::from(content))
+    }
+
+    if set_group_active {
+        set_active_prompt_group::try_handle(state, connection_id, group_id)
+    } else {
+        Ok(())
+    }
+}

--- a/src/daemon/handlers/set_prompt_content.rs
+++ b/src/daemon/handlers/set_prompt_content.rs
@@ -47,7 +47,9 @@ pub fn try_handle(
         };
 
     if let Ok(mut ui_state) = conn_state.ui_state.lock() {
-        ui_state.prompts.insert(prompt_index, Ansi::from(content))
+        ui_state
+            .prompts
+            .set_index(prompt_index, Ansi::from(content))
     }
 
     if set_group_active {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -78,6 +78,22 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
             tokio::spawn(handlers::send::handle(channel, state, connection, text));
         }
 
+        ClientRequest::RegisterPrompt {
+            connection_id: connection,
+            matcher,
+            group_id,
+            prompt_index,
+        } => {
+            tokio::spawn(handlers::register_prompt::handle(
+                channel,
+                state,
+                connection,
+                matcher,
+                group_id,
+                prompt_index,
+            ));
+        }
+
         ClientRequest::RegisterTrigger {
             connection_id: connection,
             matcher,
@@ -85,6 +101,36 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
         } => {
             tokio::spawn(handlers::register_trigger::handle(
                 channel, state, connection, matcher, handler_id,
+            ));
+        }
+
+        ClientRequest::SetPromptContent {
+            connection_id,
+            group_id,
+            prompt_index,
+            content,
+            set_group_active,
+        } => {
+            tokio::spawn(handlers::set_prompt_content::handle(
+                channel,
+                state,
+                connection_id,
+                group_id,
+                prompt_index,
+                content,
+                set_group_active.unwrap_or(true),
+            ));
+        }
+
+        ClientRequest::SetActivePromptGroup {
+            connection_id,
+            group_id,
+        } => {
+            tokio::spawn(handlers::set_active_prompt_group::handle(
+                channel,
+                state,
+                connection_id,
+                group_id,
             ));
         }
     }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -6,6 +6,8 @@ use crate::app::{processing::ansi::Ansi, Id};
 
 #[derive(Serialize)]
 pub struct MatchedText {
+    #[serde(skip_serializing)]
+    pub raw: Ansi,
     pub plain: String,
     pub ansi: String,
 }
@@ -15,6 +17,7 @@ impl MatchedText {
         return MatchedText {
             ansi: (&ansi).to_string(),
             plain: ansi.strip_ansi().to_string(),
+            raw: ansi,
         };
     }
 }
@@ -24,6 +27,14 @@ pub struct MatchContext {
     pub named: HashMap<String, MatchedText>,
     pub indexed: HashMap<usize, MatchedText>,
     pub full_match_range: Range<usize>,
+}
+
+impl MatchContext {
+    pub fn take_full_match(&mut self) -> MatchedText {
+        self.indexed
+            .remove(&0)
+            .expect("MatchContext was missing the full_match somehow")
+    }
 }
 
 #[derive(Serialize)]

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -5,6 +5,7 @@ use crate::app::Id;
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum DaemonResponse {
+    OkResult,
     ErrorResult { error: String },
 
     Connecting { connection_id: Id },


### PR DESCRIPTION
- Wire up RPC commands for managing prompts
- Add lua API for declaring prompts
- Fix prompt extraction by using multiline mode
- Uniquely identify text processors from prompts
- Add prompt group/index management on the client

TODO:

- [x] Switch between active prompt groups
- [x] Rendering a prompt may be causing artifacts. Need to investigate