### PR TITLE
Add basic support for input completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,10 +182,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "griddle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb81d22191b89b117cd12d6549544bfcba0da741efdcec7c7d2fd06a0f56363"
+dependencies = [
+ "ahash",
+ "hashbrown",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -228,6 +252,7 @@ dependencies = [
  "delegate",
  "native-tls",
  "regex",
+ "ritelinked",
  "serde",
  "serde_json",
  "telnet",
@@ -548,6 +573,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ritelinked"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f2771d255fd99f0294f13249fecd0cae6e074f86b4197ec1f1689d537b44d3"
+dependencies = [
+ "ahash",
+ "griddle",
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = "1.0"
 clap = { version = "3.1.7", features = ["derive"] }
 bytes = "1.1.0"
 crossterm = "0.23.2"
+ritelinked = "0.3.2"

--- a/lua/kodachi/completion.lua
+++ b/lua/kodachi/completion.lua
@@ -1,0 +1,13 @@
+---@alias CompletionParams { word_to_complete: string, line_to_cursor: string, line: string, cursor: number }
+
+local M = {}
+
+---@param state KodachiState
+---@param params CompletionParams
+function M.suggest_completions(state, params)
+  print('COMPLETING!', vim.inspect(params))
+  local words = { 'magic', 'grayskull', 'swift' }
+  return { words = words }
+end
+
+return M

--- a/lua/kodachi/completion.lua
+++ b/lua/kodachi/completion.lua
@@ -4,10 +4,23 @@ local M = {}
 
 ---@param state KodachiState
 ---@param params CompletionParams
-function M.suggest_completions(state, params)
-  print('COMPLETING!', vim.inspect(params))
-  local words = { 'magic', 'grayskull', 'swift' }
-  return { words = words }
+function M.suggest_completions(state, params, cb)
+  state.socket:request(
+    {
+      type = 'CompleteComposer',
+      connection_id = state.connection_id,
+      word_to_complete = params.word_to_complete,
+      line_to_cursor = params.line_to_cursor,
+      line = params.line,
+    },
+    function(response)
+      if response.type == 'ErrorResult' then
+        cb(response.error)
+      else
+        cb(nil, response)
+      end
+    end
+  )
 end
 
 return M

--- a/lua/kodachi/null-ls/completion.lua
+++ b/lua/kodachi/null-ls/completion.lua
@@ -1,0 +1,39 @@
+local h = require 'null-ls.helpers'
+local methods = require 'null-ls.methods'
+
+local COMPLETION = methods.internal.COMPLETION
+
+return h.make_builtin({
+  name = 'kodachi.composer',
+  meta = {
+    description = 'Completions for kodachi composer',
+  },
+  method = COMPLETION,
+  filetypes = {
+    'kodachi.composer',
+  },
+  generator = {
+    fn = function(params, done)
+      local get_candidates = function(entries)
+        local items = {}
+        for k, v in ipairs(entries) do
+          items[k] = {
+            label = v,
+            kind = vim.lsp.protocol.CompletionItemKind['Text'],
+          }
+        end
+
+        return items
+      end
+
+      local candidates = get_candidates(vim.fn.spellsuggest(params.word_to_complete))
+      done {
+        {
+          items = candidates,
+          isIncomplete = #candidates > 0
+        }
+      }
+    end,
+    async = true,
+  },
+})

--- a/lua/kodachi/null-ls/completion.lua
+++ b/lua/kodachi/null-ls/completion.lua
@@ -38,20 +38,28 @@ return h.make_builtin({
         }
       end
 
+      -- NOTE: Async/await might be nice, but probably not be worth the dependency on plenary
+      local cb = function(err, results)
+        if err then
+          done {}
+          return
+        end
+
+        local candidates = results and get_candidates(results.words) or {}
+        done {
+          {
+            items = candidates,
+            isIncomplete = #candidates > 0
+          }
+        }
+      end
+
       local line = params.content[params.row]
-      local results = require 'kodachi.completion'.suggest_completions(state, {
+      require 'kodachi.completion'.suggest_completions(state, {
         word_to_complete = params.word_to_complete,
         line = line,
         line_to_cursor = line:sub(1, params.col)
-      })
-
-      local candidates = results and get_candidates(results.words) or {}
-      done {
-        {
-          items = candidates,
-          isIncomplete = #candidates > 0
-        }
-      }
+      }, cb)
     end,
     async = true,
   },

--- a/lua/kodachi/ui/composer.lua
+++ b/lua/kodachi/ui/composer.lua
@@ -2,7 +2,9 @@ local states = require 'kodachi.states'
 
 local MIN_HEIGHT = 2
 
-local M = {}
+local M = {
+  _state_bufnr_for_composer_bufnr = {}
+}
 
 local function feed_backspace()
   -- Use backspace to ensure we're starting from scratch
@@ -77,6 +79,13 @@ local function on_composer_buf_entered()
   M.on_change()
 end
 
+function M.state_for_composer_bufnr(bufnr)
+  local state_bufnr = M._state_bufnr_for_composer_bufnr[bufnr]
+  if state_bufnr then
+    return states[state_bufnr]
+  end
+end
+
 ---Jump to the composer window, if any is available in the current tabpage for the KodachiState
 --associated with the current buffer, else create a new composer and enter that. This function is a
 --nop if executed *in* a composer buffer
@@ -102,6 +111,7 @@ function M.enter_or_create(opts)
     vim.cmd [[ enew ]]
     state.composer_bufnr = vim.fn.bufnr('%')
     states[state.composer_bufnr] = state
+    M._state_bufnr_for_composer_bufnr[state.composer_bufnr] = state.bufnr
     configure_current_as_composer(state)
   end
 

--- a/src/app/completion/completions.rs
+++ b/src/app/completion/completions.rs
@@ -1,30 +1,44 @@
-use std::collections::HashSet;
-
 use regex::Regex;
+
+use ritelinked::LinkedHashSet;
 
 use crate::app::processing::ansi::Ansi;
 
 use super::{transforms::WordTransform, CompletionParams};
 
+const DEFAULT_RECENCY_CAPACITY: usize = 5000;
+
 pub struct Completions {
-    incoming_words: HashSet<String>,
+    max_entries: usize,
+    incoming_words: LinkedHashSet<String>,
 }
 
 impl Default for Completions {
     fn default() -> Self {
-        Completions {
-            incoming_words: Default::default(),
-        }
+        Self::with_capacity(DEFAULT_RECENCY_CAPACITY)
     }
 }
 
 impl Completions {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Completions {
+            max_entries: capacity,
+            incoming_words: LinkedHashSet::with_capacity(capacity),
+        }
+    }
+
     pub fn process_incoming(&mut self, line: &mut Ansi) {
         let words_regex = Regex::new(r"(\w+)").unwrap();
         for m in words_regex.find_iter(&line.strip_ansi()) {
             let word = m.as_str();
             if !self.incoming_words.contains(word) {
                 self.incoming_words.insert(word.to_string());
+            }
+        }
+
+        if let Some(overage) = self.incoming_words.len().checked_sub(self.max_entries) {
+            for _ in 0..overage {
+                self.incoming_words.pop_front();
             }
         }
     }
@@ -35,5 +49,24 @@ impl Completions {
             .iter()
             .map(|s| transformer.transform(s))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capacity_test() {
+        let params = CompletionParams {
+            word_to_complete: "".to_string(),
+            line_to_cursor: "".to_string(),
+            line: "".to_string(),
+        };
+
+        let mut completions = Completions::with_capacity(2);
+        completions.process_incoming(&mut Ansi::from("for the honor"));
+        let suggestions = completions.suggest(params);
+        assert_eq!(suggestions, vec!["the", "honor"]);
     }
 }

--- a/src/app/completion/completions.rs
+++ b/src/app/completion/completions.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+
+use regex::Regex;
+
+use crate::app::processing::ansi::Ansi;
+
+use super::CompletionParams;
+
+pub struct Completions {
+    incoming_words: HashSet<String>,
+}
+
+impl Default for Completions {
+    fn default() -> Self {
+        Completions {
+            incoming_words: Default::default(),
+        }
+    }
+}
+
+impl Completions {
+    pub fn process_incoming(&mut self, line: &mut Ansi) {
+        let words_regex = Regex::new(r"(\w+)").unwrap();
+        for m in words_regex.find_iter(&line.strip_ansi()) {
+            let word = m.as_str();
+            if !self.incoming_words.contains(word) {
+                self.incoming_words.insert(word.to_string());
+            }
+        }
+    }
+
+    pub fn suggest(&self, _params: CompletionParams) -> Vec<String> {
+        // TODO
+        self.incoming_words.iter().map(|s| s.to_string()).collect()
+    }
+}

--- a/src/app/completion/completions.rs
+++ b/src/app/completion/completions.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 
 use crate::app::processing::ansi::Ansi;
 
-use super::CompletionParams;
+use super::{transforms::WordTransform, CompletionParams};
 
 pub struct Completions {
     incoming_words: HashSet<String>,
@@ -29,8 +29,11 @@ impl Completions {
         }
     }
 
-    pub fn suggest(&self, _params: CompletionParams) -> Vec<String> {
-        // TODO
-        self.incoming_words.iter().map(|s| s.to_string()).collect()
+    pub fn suggest(&self, params: CompletionParams) -> Vec<String> {
+        let transformer = WordTransform::matching_word(params.word_to_complete);
+        self.incoming_words
+            .iter()
+            .map(|s| transformer.transform(s))
+            .collect()
     }
 }

--- a/src/app/completion/mod.rs
+++ b/src/app/completion/mod.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+pub mod completions;
+
+#[derive(Debug, Deserialize)]
+pub struct CompletionParams {
+    pub word_to_complete: String,
+    pub line_to_cursor: String,
+    pub line: String,
+}

--- a/src/app/completion/mod.rs
+++ b/src/app/completion/mod.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 pub mod completions;
+pub mod transforms;
 
 #[derive(Debug, Deserialize)]
 pub struct CompletionParams {

--- a/src/app/completion/transforms.rs
+++ b/src/app/completion/transforms.rs
@@ -1,0 +1,93 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CharTransform {
+    Upper,
+    Lower,
+    Nop,
+}
+
+impl CharTransform {
+    fn from(ch: char) -> CharTransform {
+        if !ch.is_ascii_alphabetic() {
+            CharTransform::Nop
+        } else if Some(ch) == char::to_lowercase(ch).next() {
+            CharTransform::Lower
+        } else {
+            CharTransform::Upper
+        }
+    }
+
+    fn transform(&self, ch: char) -> Option<char> {
+        match self {
+            CharTransform::Upper => char::to_uppercase(ch).next(),
+            CharTransform::Lower => char::to_lowercase(ch).next(),
+            CharTransform::Nop => Some(ch),
+        }
+    }
+}
+
+impl From<Option<char>> for CharTransform {
+    fn from(option: Option<char>) -> Self {
+        match option {
+            Some(ch) => Self::from(ch),
+            None => CharTransform::Nop,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct WordTransform {
+    first: CharTransform,
+    rest: CharTransform,
+}
+
+impl WordTransform {
+    pub fn matching_word<T: AsRef<str>>(input: T) -> WordTransform {
+        let s: &str = input.as_ref();
+        let mut chars = s.chars();
+
+        let first: CharTransform = chars.next().into();
+        let rest: CharTransform = chars.next().into();
+
+        WordTransform { first, rest }
+    }
+
+    pub fn transform<T: AsRef<str>>(&self, word: T) -> String {
+        let input = word.as_ref();
+        input
+            .char_indices()
+            .filter_map(|(i, ch)| {
+                if i == 0 {
+                    self.first.transform(ch)
+                } else {
+                    self.rest.transform(ch)
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_word_test() {
+        let title = WordTransform::matching_word("Grayskull");
+        assert_eq!(title.first, CharTransform::Upper);
+        assert_eq!(title.rest, CharTransform::Lower);
+
+        let lower = WordTransform::matching_word("sword");
+        assert_eq!(lower.first, CharTransform::Lower);
+        assert_eq!(lower.rest, CharTransform::Lower);
+
+        let upper = WordTransform::matching_word("HONOR");
+        assert_eq!(upper.first, CharTransform::Upper);
+        assert_eq!(upper.rest, CharTransform::Upper);
+    }
+
+    #[test]
+    fn transform_test() {
+        let transform = WordTransform::matching_word("Grayskull");
+        assert_eq!(transform.transform("adORa"), "Adora");
+    }
+}

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 
 use crate::cli::ui::UiState;
 
-use super::{processing::text::TextProcessor, Id};
+use super::{completion::completions::Completions, processing::text::TextProcessor, Id};
 
 pub enum Outgoing {
     Text(String),
@@ -17,6 +17,7 @@ pub enum Outgoing {
 #[derive(Default, Clone)]
 pub struct ConnectionState {
     pub processor: Arc<Mutex<TextProcessor>>,
+    pub completions: Arc<Mutex<Completions>>,
     pub ui_state: Arc<Mutex<UiState>>,
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,9 +3,11 @@ use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 use self::connections::Connections;
 
 pub mod clearable;
+pub mod completion;
 pub mod connections;
 pub mod matchers;
 pub mod processing;
+pub mod processors;
 
 pub type Id = u64;
 

--- a/src/app/processors.rs
+++ b/src/app/processors.rs
@@ -1,0 +1,24 @@
+use super::{connections::ConnectionReceiver, LockableState};
+
+pub fn register_processors(state: LockableState, connection: &mut ConnectionReceiver) {
+    let connection_id = connection.id;
+    let mut processor = connection.state.processor.lock().unwrap();
+
+    let completions_state = state.clone();
+    processor.register_processor(move |line| {
+        if let Some(conn_state) = completions_state
+            .clone()
+            .lock()
+            .unwrap()
+            .connections
+            .get_state(connection_id)
+        {
+            conn_state
+                .completions
+                .lock()
+                .unwrap()
+                .process_incoming(line);
+        }
+        Ok(())
+    });
+}

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -23,7 +23,7 @@ pub enum ClientRequest {
     CompleteComposer {
         connection_id: Id,
 
-        #[serde(flatten)]
+        // #[serde(flatten)]
         params: CompletionParams,
     },
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -7,6 +7,13 @@ pub struct Connect {
     pub uri: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CompletionParams {
+    pub word_to_complete: String,
+    pub line_to_cursor: String,
+    pub line: String,
+}
+
 #[derive(Deserialize)]
 #[serde(tag = "type")]
 pub enum ClientRequest {
@@ -17,6 +24,12 @@ pub enum ClientRequest {
     Send {
         connection_id: Id,
         text: String,
+    },
+
+    /// Request suggestions to complete some word in the composer
+    CompleteComposer {
+        connection_id: Id,
+        params: CompletionParams,
     },
 
     RegisterTrigger {

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -29,6 +29,8 @@ pub enum ClientRequest {
     /// Request suggestions to complete some word in the composer
     CompleteComposer {
         connection_id: Id,
+
+        #[serde(flatten)]
         params: CompletionParams,
     },
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -1,17 +1,10 @@
 use serde::Deserialize;
 
-use crate::app::{matchers::MatcherSpec, Id};
+use crate::app::{completion::CompletionParams, matchers::MatcherSpec, Id};
 
 #[derive(Debug, Deserialize)]
 pub struct Connect {
     pub uri: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CompletionParams {
-    pub word_to_complete: String,
-    pub line_to_cursor: String,
-    pub line: String,
 }
 
 #[derive(Deserialize)]

--- a/src/daemon/handlers/complete_composer.rs
+++ b/src/daemon/handlers/complete_composer.rs
@@ -1,0 +1,23 @@
+use std::io;
+
+use crate::{
+    app::{Id, LockableState},
+    daemon::{channel::Channel, commands},
+};
+
+pub async fn handle(
+    channel: Channel,
+    state: LockableState,
+    connection_id: Id,
+    params: commands::CompletionParams,
+) -> io::Result<()> {
+    let words = vec![
+        "grayskull".to_string(),
+        "magic".to_string(),
+        "swift".to_string(),
+        "wind".to_string(),
+    ];
+
+    channel.respond(crate::daemon::responses::DaemonResponse::CompleteResult { words });
+    Ok(())
+}

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod clear;
+pub mod complete_composer;
 pub mod connect;
 pub mod disconnect;
 pub mod register_prompt;

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -43,7 +43,7 @@ pub async fn handle(
     processor_ref
         .lock()
         .unwrap()
-        .register(id, compiled, move |mut context, _| {
+        .register_matcher(id, compiled, move |mut context, _| {
             set_prompt_content::try_handle(
                 state.clone(),
                 connection_id,

--- a/src/daemon/handlers/register_trigger.rs
+++ b/src/daemon/handlers/register_trigger.rs
@@ -32,7 +32,7 @@ pub async fn handle(
         }
     };
 
-    processor_ref.lock().unwrap().register(
+    processor_ref.lock().unwrap().register_matcher(
         MatcherId::Handler(handler_id),
         compiled,
         move |context, mut receiver| {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -41,11 +41,10 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
         let request: Request = match serde_json::from_str(&raw_json) {
             Ok(request) => request,
             Err(err) => {
-                // return Err(io::Error::new(
-                //     io::ErrorKind::InvalidInput,
-                //     format!("Unable to parse input `{}`: {}", raw_json, err),
-                // ));
-                panic!("Unable to parse input `{}`: {}", raw_json, err);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Unable to parse input `{}`: {}", raw_json, err),
+                ));
             }
         };
         let state = shared_state.clone();

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -10,4 +10,6 @@ pub enum DaemonResponse {
 
     Connecting { connection_id: Id },
     SendResult { sent: bool },
+
+    CompleteResult { words: Vec<String> },
 }


### PR DESCRIPTION
This PR sets the groundwork for a more elaborate system of completion suggestions, like the one used by iaido/judo, with a very basic LRU cache of words received from the server. We lean on null-ls to provide completions, but pulled out the actual machinery to potentially support other ways of integrating with the editor in the future.

Completions are managed entirely by the Rust process, and are retrieved by RPC. Future work will likely want to limit/paginate suggestions and/or provide some basic filtering in Rust so clients don't have to worry about massive RPC responses.

Since I added some error handling as part of debugging, this PR also goes ahead and further cleans up error handling. The process will now exit properly when the main loop encounters an error!

- Scaffold out fake null-ls completion source
- Complete scaffolding for null-ls completion
- Scaffold RPC for completion
- Properly flatten the completion params
- Scaffold out some weak text completions based on received words
- Transform word suggestions to match the input word's case
- Use a LinkedHashSet-based LRU to prevent infinite completions growth
