### PR TITLE
Add History support

### DIFF
--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -101,9 +101,10 @@ function Socket:request_blocking(request, timeout_ms)
     state.done = true
   end)
 
+  local interval = 20
   local received_done, error_code = vim.wait(timeout, function()
     return state.done
-  end)
+  end, interval)
 
   if received_done then
     return state.response

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -4,6 +4,8 @@
 ---@alias DisconnectedNotification { type: "'Disconnected'", connection_id: number  }
 ---@alias KodachiNotification TriggerMatchedNotification | DisconnectedNotification
 
+local DEFAULT_BLOCKING_TIMEOUT = 500
+
 ---@class Socket
 ---@field name string
 ---@field _receivers any[]
@@ -90,7 +92,7 @@ function Socket:request(request, cb)
 end
 
 function Socket:request_blocking(request, timeout_ms)
-  local timeout = timeout_ms or 5000
+  local timeout = timeout_ms or DEFAULT_BLOCKING_TIMEOUT
 
   local state = { done = false }
 

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -89,8 +89,8 @@ function Socket:request(request, cb)
   return request.id
 end
 
-function Socket:request_blocking(request, timeout)
-  local timeout = timeout or 5000
+function Socket:request_blocking(request, timeout_ms)
+  local timeout = timeout_ms or 5000
 
   local state = { done = false }
 
@@ -108,9 +108,9 @@ function Socket:request_blocking(request, timeout)
   end
 
   if error_code == -1 then
-    error("ERROR: Timed out performing ", request.type)
+    error("ERROR: Timed out performing " .. request.type)
   else
-    error("ERROR: Interrupted performing ", request.type)
+    error("ERROR: Interrupted performing " .. request.type)
   end
 end
 

--- a/lua/kodachi/ui/composer.lua
+++ b/lua/kodachi/ui/composer.lua
@@ -31,7 +31,7 @@ end
 ---@param state KodachiState
 local function configure_current_as_composer(state)
   -- Enable null-ls completions
-  -- NOTE: These msut be done *before* setting buftype, or else null-ls ignores!
+  -- NOTE: These must be done *before* setting buftype, or else null-ls ignores!
   local buf_name = 'kodachi.composer:' .. state.connection_id
   local existing_bufnr = vim.fn.bufnr(buf_name)
   if existing_bufnr ~= -1 then
@@ -46,16 +46,20 @@ local function configure_current_as_composer(state)
   vim.wo.winfixheight = true
 
   -- Handle submitting
-  vim.cmd [[ inoremap <buffer> <cr> <cmd>lua require'kodachi.ui.composer'.submit()<cr> ]]
-  vim.cmd [[ nnoremap <buffer> <cr> <cmd>lua require'kodachi.ui.composer'.submit()<cr> ]]
+  vim.cmd [[inoremap <buffer> <cr> <cmd>lua require'kodachi.ui.composer'.submit()<cr>]]
+  vim.cmd [[nnoremap <buffer> <cr> <cmd>lua require'kodachi.ui.composer'.submit()<cr>]]
 
   -- Support inserting newlines
-  vim.cmd [[ inoremap <buffer> <s-cr> <cr> ]]
-  vim.cmd [[ inoremap <buffer> <a-cr> <cr> ]]
+  vim.cmd [[inoremap <buffer> <s-cr> <cr>]]
+  vim.cmd [[inoremap <buffer> <a-cr> <cr>]]
 
   -- Make it natural to leave
-  vim.cmd [[ inoremap <buffer> <c-c> <esc>ZQ ]]
-  vim.cmd [[ nnoremap <buffer> <c-c> ZQ ]]
+  vim.cmd [[inoremap <buffer> <c-c> <esc>ZQ]]
+  vim.cmd [[nnoremap <buffer> <c-c> ZQ]]
+
+  -- In-line History navigation
+  vim.cmd [[nnoremap <buffer> k <cmd>lua require'kodachi.ui.composer'.maybe_history('older')<cr>]]
+  vim.cmd [[nnoremap <buffer> j <cmd>lua require'kodachi.ui.composer'.maybe_history('newer')<cr>]]
 end
 
 local function measure_line_width(linenr)
@@ -168,6 +172,18 @@ function M.hide(opts)
       end
     end
   end
+end
+
+---@param direction '"older"'|'"newer"'
+function M.maybe_history(direction)
+  local moves_by_direction = {
+    older = { offset = -1, key = 'k' },
+    newer = { offset = 1, key = 'j' },
+  }
+  local moves = moves_by_direction[direction]
+
+  -- TODO try scrolling history
+  vim.api.nvim_feedkeys(moves.key, 'n', false)
 end
 
 function M.on_change()

--- a/lua/kodachi/ui/composer.lua
+++ b/lua/kodachi/ui/composer.lua
@@ -155,6 +155,11 @@ function M.compute_height()
   return vim.fn.max { MIN_HEIGHT, height + 1 }
 end
 
+function M.get_content()
+  local lines = vim.fn.getline(1, '$')
+  return table.concat(lines, '\n')
+end
+
 ---@param opts { clear:boolean }|nil
 function M.hide(opts)
   local state = state_composer()
@@ -209,6 +214,7 @@ function M.scroll_history(direction)
     type = 'ScrollHistory',
     connection_id = state.connection_id,
     direction = direction,
+    content = M.get_content(),
     cursor = M._active_cursor,
   }
 
@@ -234,8 +240,7 @@ function M.submit()
     return
   end
 
-  local lines = vim.fn.getline(1, '$')
-  local text = table.concat(lines, '\n')
+  local text = M.get_content()
 
   M.clear()
 

--- a/lua/kodachi/ui/composer.lua
+++ b/lua/kodachi/ui/composer.lua
@@ -203,6 +203,11 @@ function M.maybe_history(direction)
   end
 end
 
+---@param content string
+function M.set_content(content)
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, vim.fn.split(content, '\n'))
+end
+
 ---@param direction '"Older"'|'"Newer"'
 function M.scroll_history(direction)
   local state = state_composer()
@@ -223,7 +228,8 @@ function M.scroll_history(direction)
     return
   end
 
-  print('TODO', vim.inspect(response))
+  M.set_content(response.new_content)
+  M._active_cursor = response.cursor
 end
 
 function M.on_change()

--- a/lua/kodachi/ui/history.lua
+++ b/lua/kodachi/ui/history.lua
@@ -1,0 +1,42 @@
+local function swap_active(new_list)
+  local old = {}
+  local limit = vim.fn.histnr('@')
+  if limit > 0 then
+    for i = 1, limit do
+      table.insert(old, vim.fn.histget('@', i))
+    end
+  end
+
+  vim.fn.histdel('@')
+
+  for _, entry in ipairs(new_list) do
+    vim.fn.histadd('@', entry)
+  end
+
+  return old
+end
+
+local function perform_input()
+  return vim.fn.input('>')
+end
+
+local M = {}
+
+function M.open()
+  -- TODO: Setup autocmd to use the right filetype in the cmdlinewin
+  -- TODO: Query for history
+  local old_history = swap_active({ 'for', 'honor', 'grayskull' })
+
+  local ok, input = pcall(perform_input)
+
+  swap_active(old_history)
+
+  if ok then
+    local state = require 'kodachi.states'.current_connected()
+    if state then
+      state:send(input)
+    end
+  end
+end
+
+return M

--- a/lua/kodachi/ui/history.lua
+++ b/lua/kodachi/ui/history.lua
@@ -51,7 +51,7 @@ local function show_history(entries)
 
   History.restore()
 
-  if ok then
+  if ok and input ~= '' then
     local state = require 'kodachi.states'.current_connected()
     if state then
       state:send(input)

--- a/lua/kodachi/ui/window.lua
+++ b/lua/kodachi/ui/window.lua
@@ -1,4 +1,4 @@
-local states = require'kodachi.states'
+local states = require 'kodachi.states'
 
 local M = {}
 
@@ -12,7 +12,10 @@ function M.configure_current()
 
   -- TODO Unify and simplify this
   vim.cmd [[ nnoremap <buffer> i <cmd>lua require'kodachi.ui.composer'.enter_or_create { insert = true } <cr> ]]
-  vim.cmd [[ nnoremap <buffer> I <cmd>lua require'kodachi.ui.composer'.enter_or_create{ insert = true }<cr> ]]
+  vim.cmd [[ nnoremap <buffer> I <cmd>lua require'kodachi.ui.composer'.enter_or_create { insert = true }<cr> ]]
+
+  vim.cmd [[ nnoremap <Plug>KodachiPrompt <cmd>lua require'kodachi.ui.history'.open()<cr>]]
+  vim.cmd([[ nnoremap <buffer> qi <Plug>KodachiPrompt]] .. vim.o.cedit)
 end
 
 return M

--- a/src/app/completion/completions.rs
+++ b/src/app/completion/completions.rs
@@ -1,16 +1,13 @@
 use regex::Regex;
 
-use ritelinked::LinkedHashSet;
-
-use crate::app::processing::ansi::Ansi;
+use crate::app::{history::History, processing::ansi::Ansi};
 
 use super::{transforms::WordTransform, CompletionParams};
 
 const DEFAULT_RECENCY_CAPACITY: usize = 5000;
 
 pub struct Completions {
-    max_entries: usize,
-    incoming_words: LinkedHashSet<String>,
+    history: History<String>,
 }
 
 impl Default for Completions {
@@ -22,30 +19,22 @@ impl Default for Completions {
 impl Completions {
     pub fn with_capacity(capacity: usize) -> Self {
         Completions {
-            max_entries: capacity,
-            incoming_words: LinkedHashSet::with_capacity(capacity),
+            history: History::with_capacity(capacity),
         }
     }
 
     pub fn process_incoming(&mut self, line: &mut Ansi) {
         let words_regex = Regex::new(r"(\w+)").unwrap();
-        for m in words_regex.find_iter(&line.strip_ansi()) {
-            let word = m.as_str();
-            if !self.incoming_words.contains(word) {
-                self.incoming_words.insert(word.to_string());
-            }
-        }
-
-        if let Some(overage) = self.incoming_words.len().checked_sub(self.max_entries) {
-            for _ in 0..overage {
-                self.incoming_words.pop_front();
-            }
-        }
+        self.history.insert_many(
+            words_regex
+                .find_iter(&line.strip_ansi())
+                .map(|m| m.as_str().to_string()),
+        );
     }
 
     pub fn suggest(&self, params: CompletionParams) -> Vec<String> {
         let transformer = WordTransform::matching_word(params.word_to_complete);
-        self.incoming_words
+        self.history
             .iter()
             .map(|s| transformer.transform(s))
             .collect()

--- a/src/app/completion/completions.rs
+++ b/src/app/completion/completions.rs
@@ -32,6 +32,12 @@ impl Completions {
         );
     }
 
+    pub fn process_outgoing(&mut self, line: String) {
+        let words_regex = Regex::new(r"(\w+)").unwrap();
+        self.history
+            .insert_many(words_regex.find_iter(&line).map(|m| m.as_str().to_string()));
+    }
+
     pub fn suggest(&self, params: CompletionParams) -> Vec<String> {
         let transformer = WordTransform::matching_word(params.word_to_complete);
         self.history

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -7,7 +7,9 @@ use tokio::sync::mpsc;
 
 use crate::cli::ui::UiState;
 
-use super::{completion::completions::Completions, processing::text::TextProcessor, Id};
+use super::{
+    completion::completions::Completions, history::History, processing::text::TextProcessor, Id,
+};
 
 pub enum Outgoing {
     Text(String),
@@ -18,6 +20,7 @@ pub enum Outgoing {
 pub struct ConnectionState {
     pub processor: Arc<Mutex<TextProcessor>>,
     pub completions: Arc<Mutex<Completions>>,
+    pub sent: Arc<Mutex<History<String>>>,
     pub ui_state: Arc<Mutex<UiState>>,
 }
 

--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 const DEFAULT_HISTORY_CAPACITY: usize = 10000;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, PartialEq, Eq)]
 pub enum HistoryScrollDirection {
     Older,
     Newer,
@@ -46,6 +46,10 @@ impl<T: Eq + Hash> History<T> {
 
     pub fn iter(&self) -> ritelinked::linked_hash_set::Iter<T> {
         self.entries.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
     }
 }
 

--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 const DEFAULT_HISTORY_CAPACITY: usize = 10000;
 
-#[derive(Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq)]
 pub enum HistoryScrollDirection {
     Older,
     Newer,

--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -1,0 +1,63 @@
+use std::hash::Hash;
+
+use ritelinked::LinkedHashSet;
+
+const DEFAULT_HISTORY_CAPACITY: usize = 10000;
+
+pub struct History<T> {
+    max_entries: usize,
+    entries: LinkedHashSet<T>,
+}
+
+impl<T: Eq + Hash> Default for History<T> {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_HISTORY_CAPACITY)
+    }
+}
+
+impl<T: Eq + Hash> History<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            max_entries: capacity,
+            entries: LinkedHashSet::default(),
+        }
+    }
+
+    pub fn insert(&mut self, entry: T) {
+        self.insert_many(vec![entry]);
+    }
+
+    pub fn insert_many<I: IntoIterator<Item = T>>(&mut self, entries: I) {
+        self.entries.extend(entries);
+
+        if let Some(overage) = self.entries.len().checked_sub(self.max_entries) {
+            for _ in 0..overage {
+                self.entries.pop_front();
+            }
+        }
+    }
+
+    pub fn iter(&self) -> ritelinked::linked_hash_set::Iter<T> {
+        self.entries.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a History<T> {
+    type Item = &'a T;
+
+    type IntoIter = ritelinked::linked_hash_set::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.iter()
+    }
+}
+
+impl<T> IntoIterator for History<T> {
+    type Item = T;
+
+    type IntoIter = ritelinked::linked_hash_set::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}

--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -1,8 +1,15 @@
 use std::hash::Hash;
 
 use ritelinked::LinkedHashSet;
+use serde::Deserialize;
 
 const DEFAULT_HISTORY_CAPACITY: usize = 10000;
+
+#[derive(Deserialize)]
+pub enum HistoryScrollDirection {
+    Older,
+    Newer,
+}
 
 pub struct History<T> {
     max_entries: usize,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@ use self::connections::Connections;
 pub mod clearable;
 pub mod completion;
 pub mod connections;
+pub mod history;
 pub mod matchers;
 pub mod processing;
 pub mod processors;

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::{Debug, Display},
+    hash::Hash,
     ops::{Add, Deref, Range, RangeBounds},
 };
 
@@ -76,11 +77,19 @@ impl Debug for Ansi {
     }
 }
 
+impl Hash for Ansi {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state)
+    }
+}
+
 impl PartialEq for Ansi {
     fn eq(&self, other: &Self) -> bool {
         self.bytes.eq(&other.bytes)
     }
 }
+
+impl Eq for Ansi {}
 
 impl Deref for Ansi {
     type Target = str;

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -32,6 +32,7 @@ pub enum ClientRequest {
     ScrollHistory {
         connection_id: Id,
         direction: HistoryScrollDirection,
+        content: String,
         cursor: Option<HistoryCursor>,
     },
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
-use crate::app::{completion::CompletionParams, matchers::MatcherSpec, Id};
+use crate::app::{
+    completion::CompletionParams, history::HistoryScrollDirection, matchers::MatcherSpec, Id,
+};
 
 use super::protocol::cursors::HistoryCursor;
 
@@ -24,6 +26,12 @@ pub enum ClientRequest {
     GetHistory {
         connection_id: Id,
         limit: usize,
+        cursor: Option<HistoryCursor>,
+    },
+
+    ScrollHistory {
+        connection_id: Id,
+        direction: HistoryScrollDirection,
         cursor: Option<HistoryCursor>,
     },
 

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 
 use crate::app::{completion::CompletionParams, matchers::MatcherSpec, Id};
 
+use super::protocol::cursors::HistoryCursor;
+
 #[derive(Debug, Deserialize)]
 pub struct Connect {
     pub uri: String,
@@ -17,6 +19,12 @@ pub enum ClientRequest {
     Send {
         connection_id: Id,
         text: String,
+    },
+
+    GetHistory {
+        connection_id: Id,
+        limit: usize,
+        cursor: Option<HistoryCursor>,
     },
 
     /// Request suggestions to complete some word in the composer

--- a/src/daemon/handlers/get_history.rs
+++ b/src/daemon/handlers/get_history.rs
@@ -41,6 +41,7 @@ pub async fn handle(
             offset: offset + limit,
             limit,
             version: 0,
+            initial_content: None,
         })
     } else {
         None

--- a/src/daemon/handlers/get_history.rs
+++ b/src/daemon/handlers/get_history.rs
@@ -22,7 +22,7 @@ pub async fn handle(
 
     let history = connection.sent.lock().unwrap();
 
-    // TODO If the history version doesn't match, throw away the cursor
+    // If the history version doesn't match, throw away the cursor
     let version = history.version();
     let request_cursor = if provided_cursor.as_ref().map(|c| c.version) == Some(version) {
         provided_cursor.clone()

--- a/src/daemon/handlers/get_history.rs
+++ b/src/daemon/handlers/get_history.rs
@@ -1,0 +1,54 @@
+use crate::{
+    app::{Id, LockableState},
+    daemon::{channel::Channel, protocol::cursors::HistoryCursor, responses::DaemonResponse},
+};
+
+pub async fn handle(
+    channel: Channel,
+    mut state: LockableState,
+    connection_id: Id,
+    default_limit: usize,
+    request_cursor: Option<HistoryCursor>,
+) {
+    let connection =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            channel.respond(DaemonResponse::ErrorResult {
+                error: "Not connected".to_string(),
+            });
+            return;
+        };
+
+    // TODO If the history version doesn't match, throw away the cursor
+
+    let limit = request_cursor.as_ref().map_or(default_limit, |c| c.limit);
+    let offset = request_cursor.as_ref().map_or(0, |c| c.offset);
+
+    let mut entries: Vec<String> = connection
+        .sent
+        .lock()
+        .unwrap()
+        .iter()
+        .skip(offset)
+        .take(limit + 1)
+        .map(|entry| entry.to_owned())
+        .collect();
+
+    let cursor = if entries.len() > limit {
+        // TODO encode history "version"
+        Some(HistoryCursor {
+            offset: offset + limit,
+            limit,
+            version: 0,
+        })
+    } else {
+        None
+    };
+
+    if cursor.is_some() {
+        entries.pop();
+    }
+
+    channel.respond(DaemonResponse::HistoryResult { entries, cursor });
+}

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod clear;
 pub mod complete_composer;
 pub mod connect;
 pub mod disconnect;
+pub mod get_history;
 pub mod register_prompt;
 pub mod register_trigger;
 pub mod send;

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod disconnect;
 pub mod get_history;
 pub mod register_prompt;
 pub mod register_trigger;
+pub mod scroll_history;
 pub mod send;
 pub mod set_active_prompt_group;
 pub mod set_prompt_content;

--- a/src/daemon/handlers/scroll_history.rs
+++ b/src/daemon/handlers/scroll_history.rs
@@ -1,0 +1,16 @@
+use crate::{
+    app::{history::HistoryScrollDirection, Id, LockableState},
+    daemon::{channel::Channel, protocol::cursors::HistoryCursor, responses::DaemonResponse},
+};
+
+pub async fn handle(
+    channel: Channel,
+    mut state: LockableState,
+    connection_id: Id,
+    direction: HistoryScrollDirection,
+    cursor: Option<HistoryCursor>,
+) {
+    channel.respond(DaemonResponse::ErrorResult {
+        error: "Not supported".to_string(),
+    });
+}

--- a/src/daemon/handlers/scroll_history.rs
+++ b/src/daemon/handlers/scroll_history.rs
@@ -5,12 +5,97 @@ use crate::{
 
 pub async fn handle(
     channel: Channel,
+    state: LockableState,
+    connection_id: Id,
+    direction: HistoryScrollDirection,
+    content: String,
+    cursor: Option<HistoryCursor>,
+) {
+    channel.respond(try_handle(state, connection_id, direction, content, cursor));
+}
+
+pub fn try_handle(
     mut state: LockableState,
     connection_id: Id,
     direction: HistoryScrollDirection,
+    content: String,
     cursor: Option<HistoryCursor>,
-) {
-    channel.respond(DaemonResponse::ErrorResult {
-        error: "Not supported".to_string(),
-    });
+) -> DaemonResponse {
+    let connection =
+        if let Some(reference) = state.lock().unwrap().connections.get_state(connection_id) {
+            reference.clone()
+        } else {
+            return DaemonResponse::ErrorResult {
+                error: "Not connected".to_string(),
+            };
+        };
+
+    // TODO If the history version doesn't match, throw away the cursor
+
+    let offset = cursor.as_ref().map_or(0, |c| c.offset);
+    let version = 0; // TODO
+
+    let history = connection.sent.lock().unwrap();
+
+    let next_offset = match (cursor, direction) {
+        (None, HistoryScrollDirection::Older) => history.len().checked_sub(1),
+        (Some(_), HistoryScrollDirection::Older) => offset.checked_sub(1),
+        (None, HistoryScrollDirection::Newer) => None,
+        (Some(_), HistoryScrollDirection::Newer) => Some(offset + 1),
+    };
+    let next_item = if let Some(next_offset) = next_offset {
+        history.iter().nth(next_offset).map(|v| v.to_owned())
+    } else {
+        None
+    };
+
+    if let Some(item) = next_item {
+        DaemonResponse::HistoryScrollResult {
+            new_content: item,
+            cursor: Some(HistoryCursor {
+                limit: 1,
+                offset: next_offset.unwrap(),
+                version,
+            }),
+        }
+    } else {
+        DaemonResponse::HistoryScrollResult {
+            new_content: content,
+            cursor: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_to_most_recent_test() {
+        let mut state = LockableState::default();
+        let conn = state.lock().unwrap().connections.create();
+        let connection_id = conn.id;
+        conn.state
+            .sent
+            .lock()
+            .unwrap()
+            .insert_many(vec!["First".to_string(), "Second".to_string()]);
+
+        let response = try_handle(
+            state,
+            connection_id,
+            HistoryScrollDirection::Older,
+            "".to_string(),
+            None,
+        );
+        let (new_content, _cursor) = match response {
+            DaemonResponse::HistoryScrollResult {
+                new_content,
+                cursor,
+            } => (new_content, cursor),
+            _ => panic!("Didn't scroll successfully"),
+        };
+
+        assert_eq!(new_content, "Second");
+    }
 }

--- a/src/daemon/handlers/send.rs
+++ b/src/daemon/handlers/send.rs
@@ -6,10 +6,18 @@ use crate::{
 pub async fn handle(channel: Channel, mut state: LockableState, connection_id: Id, text: String) {
     let outbox = state.lock().unwrap().connections.get_outbox(connection_id);
     let sent = if let Some(outbox) = outbox {
-        outbox.send(Outgoing::Text(text)).await.is_ok()
+        outbox.send(Outgoing::Text(text.clone())).await.is_ok()
     } else {
         false
     };
+
+    if let Some(connection) = state.lock().unwrap().connections.get_state(connection_id) {
+        let mut sent = connection.sent.lock().unwrap();
+        sent.insert(text.clone());
+
+        let mut completions = connection.completions.lock().unwrap();
+        completions.process_outgoing(text);
+    }
 
     channel.respond(DaemonResponse::SendResult { sent });
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -95,6 +95,20 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
             ));
         }
 
+        ClientRequest::GetHistory {
+            connection_id,
+            limit,
+            cursor,
+        } => {
+            tokio::spawn(handlers::get_history::handle(
+                channel,
+                state,
+                connection_id,
+                limit,
+                cursor,
+            ));
+        }
+
         ClientRequest::RegisterPrompt {
             connection_id: connection,
             matcher,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -138,6 +138,7 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
         ClientRequest::ScrollHistory {
             connection_id,
             direction,
+            content,
             cursor,
         } => {
             tokio::spawn(handlers::scroll_history::handle(
@@ -145,6 +146,7 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
                 state,
                 connection_id,
                 direction,
+                content,
                 cursor,
             ));
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -135,6 +135,20 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
             ));
         }
 
+        ClientRequest::ScrollHistory {
+            connection_id,
+            direction,
+            cursor,
+        } => {
+            tokio::spawn(handlers::scroll_history::handle(
+                channel,
+                state,
+                connection_id,
+                direction,
+                cursor,
+            ));
+        }
+
         ClientRequest::SetPromptContent {
             connection_id,
             group_id,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub mod cursors;
+
 use crate::app::Id;
 
 use super::{

--- a/src/daemon/protocol/cursors.rs
+++ b/src/daemon/protocol/cursors.rs
@@ -2,11 +2,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::Id;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HistoryCursor {
     pub limit: usize,
     pub offset: usize,
     pub version: Id,
+    pub initial_content: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct JsonSerializable {
+    pub limit: usize,
+    pub offset: usize,
+    pub version: Id,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_content: Option<String>,
 }
 
 impl Serialize for HistoryCursor {
@@ -14,7 +24,13 @@ impl Serialize for HistoryCursor {
     where
         S: serde::Serializer,
     {
-        match serde_json::to_string(self) {
+        let s = JsonSerializable {
+            limit: self.limit,
+            offset: self.offset,
+            version: self.version,
+            initial_content: self.initial_content.clone(),
+        };
+        match serde_json::to_string(&s) {
             Ok(as_str) => serializer.serialize_str(&as_str),
             Err(err) => panic!("Unable to serialize cursor: {:?}", err),
         }
@@ -27,8 +43,13 @@ impl<'de> Deserialize<'de> for HistoryCursor {
         D: serde::Deserializer<'de>,
     {
         let encoded = String::deserialize(deserializer)?;
-        match serde_json::from_str::<HistoryCursor>(&encoded) {
-            Ok(cursor) => Ok(cursor),
+        match serde_json::from_str::<JsonSerializable>(&encoded) {
+            Ok(cursor) => Ok(HistoryCursor {
+                limit: cursor.limit,
+                offset: cursor.offset,
+                version: cursor.version,
+                initial_content: cursor.initial_content,
+            }),
             Err(err) => panic!("{:?}", err),
         }
     }

--- a/src/daemon/protocol/cursors.rs
+++ b/src/daemon/protocol/cursors.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::Id;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HistoryCursor {
     pub limit: usize,
     pub offset: usize,

--- a/src/daemon/protocol/cursors.rs
+++ b/src/daemon/protocol/cursors.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+use crate::app::Id;
+
+pub struct HistoryCursor {
+    pub limit: usize,
+    pub offset: usize,
+    pub version: Id,
+}
+
+impl Serialize for HistoryCursor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match serde_json::to_string(self) {
+            Ok(as_str) => serializer.serialize_str(&as_str),
+            Err(err) => panic!("Unable to serialize cursor: {:?}", err),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HistoryCursor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        match serde_json::from_str::<HistoryCursor>(&encoded) {
+            Ok(cursor) => Ok(cursor),
+            Err(err) => panic!("{:?}", err),
+        }
+    }
+}

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -26,4 +26,8 @@ pub enum DaemonResponse {
         entries: Vec<String>,
         cursor: Option<HistoryCursor>,
     },
+    HistoryScrollResult {
+        new_content: String,
+        cursor: Option<HistoryCursor>,
+    },
 }

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -2,14 +2,28 @@ use serde::Serialize;
 
 use crate::app::Id;
 
+use super::protocol::cursors::HistoryCursor;
+
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum DaemonResponse {
     OkResult,
-    ErrorResult { error: String },
+    ErrorResult {
+        error: String,
+    },
 
-    Connecting { connection_id: Id },
-    SendResult { sent: bool },
+    Connecting {
+        connection_id: Id,
+    },
+    SendResult {
+        sent: bool,
+    },
 
-    CompleteResult { words: Vec<String> },
+    CompleteResult {
+        words: Vec<String>,
+    },
+    HistoryResult {
+        entries: Vec<String>,
+        cursor: Option<HistoryCursor>,
+    },
 }


### PR DESCRIPTION
This PR adds support for recording outgoing/"sent" history, and managing it from the Rust process. We have two options here: 

1. A paginated `GetHistory` command for bulk fetches. We use this with a new `qi` mapping to open a cmdline window with recently sent history
2. A cursor-based `ScrollHistory` command for browsing history one-at-a-time. We use this with the typical `j` and `k` mappings at the vertical boundaries of the composer window to "scroll" through old sent messages.

TODO:

- [x] History Versioning