### PR TITLE
Add basic telnet option handling with MTTS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "clap",
  "crossterm",
  "delegate",
+ "log",
  "native-tls",
  "regex",
  "ritelinked",
@@ -296,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +274,8 @@ dependencies = [
  "ritelinked",
  "serde",
  "serde_json",
+ "supports-color",
+ "supports-unicode",
  "tokio",
  "tokio-native-tls",
  "url",
@@ -706,6 +714,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b945e45b417b125a8ec51f1b7df2f8df7920367700d1f98aedd21e5735f8b2"
+dependencies = [
+ "atty",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ crossterm = "0.23.2"
 ritelinked = "0.3.2"
 async-trait = "0.1.59"
 log = { version = "0.4.17", features = ["std"] }
+supports-unicode = "1.0.2"
+supports-color = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ bytes = "1.1.0"
 crossterm = "0.23.2"
 ritelinked = "0.3.2"
 async-trait = "0.1.59"
+log = { version = "0.4.17", features = ["std"] }

--- a/lua/kodachi/ui/term.lua
+++ b/lua/kodachi/ui/term.lua
@@ -17,6 +17,10 @@ function M.spawn_unix(opts)
 
   local session_name = vim.fn.rand()
 
+  local env = {
+    DEBUG = vim.g.KODACHI_DEBUG,
+  }
+
   local cmd = vim.tbl_flatten {
     tmux_wrap and {
       'tmux',
@@ -25,6 +29,7 @@ function M.spawn_unix(opts)
       'new-session',
       '-n', 'kodachi',
       '-s', session_name,
+      '-e', 'DEBUG=' .. env.DEBUG,
     } or {},
     M.debug and { 'cargo', 'run', '--' } or kodachi_exe,
     'unix', opts.socket_name,
@@ -39,6 +44,7 @@ function M.spawn_unix(opts)
 
   local job_id = vim.fn.termopen(cmd, {
     cwd = kodachi_root,
+    env = env,
     on_exit = function(_, _, _)
       opts.on_exit()
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,29 @@
+use std::{collections::HashSet, env};
+
+pub struct KodachiLogger {
+    pub enabled_namespaces: HashSet<String>,
+}
+
+impl Default for KodachiLogger {
+    fn default() -> Self {
+        let string = env::var("DEBUG").unwrap_or_default();
+        let enabled_namespaces = string.split(',').map(|s| s.to_string()).collect();
+        KodachiLogger { enabled_namespaces }
+    }
+}
+
+impl log::Log for KodachiLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.enabled_namespaces.contains(metadata.target())
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            println!("[{}] {}", record.target(), record.args());
+        }
+    }
+
+    fn flush(&self) {
+        // nop
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,13 @@ use cli::{Cli, Commands};
 mod app;
 mod cli;
 mod daemon;
+mod logging;
 mod net;
 mod transport;
 
 use cli::stdio::StdinReader;
 use crossterm::style::{Print, ResetColor};
+use logging::KodachiLogger;
 
 async fn run(cli: Cli) -> io::Result<()> {
     match &cli.command {
@@ -36,6 +38,9 @@ async fn run(cli: Cli) -> io::Result<()> {
 
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
+
+    log::set_boxed_logger(Box::new(KodachiLogger::default())).unwrap();
+    log::set_max_level(log::LevelFilter::Trace);
 
     let rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(run(cli));

--- a/src/transport/telnet/mod.rs
+++ b/src/transport/telnet/mod.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 use tokio_native_tls::{TlsConnector, TlsStream};
 
-use self::options::{OptionsNegotiator, OptionsNegotiatorBuilder};
+use self::options::TelnetOptionsManager;
 
 use super::{Transport, TransportEvent};
 
@@ -22,7 +22,7 @@ pub struct TelnetTransport<S: AsyncRead + AsyncWrite> {
     buffer: BytesMut,
     stream: S,
     telnet: TelnetProcessor,
-    options: OptionsNegotiator,
+    options: TelnetOptionsManager,
 }
 
 impl TelnetTransport<TcpStream> {
@@ -52,13 +52,12 @@ impl TelnetTransport<TlsStream<TcpStream>> {
 impl<S: AsyncRead + AsyncWrite + Unpin + Send> TelnetTransport<S> {
     async fn connect_with_stream(stream: S, buffer_size: usize) -> io::Result<Self> {
         let buffer = BytesMut::with_capacity(buffer_size);
-        let options = OptionsNegotiatorBuilder::default().build();
 
         Ok(Self {
             buffer,
             stream,
             telnet: TelnetProcessor::default(),
-            options,
+            options: TelnetOptionsManager::default(),
         })
     }
 

--- a/src/transport/telnet/options.rs
+++ b/src/transport/telnet/options.rs
@@ -1,0 +1,84 @@
+use std::{collections::HashMap, io};
+
+use log::trace;
+use tokio::io::AsyncWrite;
+
+use crate::transport::telnet::processor::TelnetEvent;
+
+use super::protocol::{NegotiationType, TelnetOption};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OptionState {
+    Accept(NegotiationType),
+    Will,
+    Do,
+}
+
+pub struct OptionsNegotiator {
+    options: HashMap<TelnetOption, OptionState>,
+}
+
+impl OptionsNegotiator {
+    pub async fn negotiate<S: AsyncWrite + Unpin + Send>(
+        &mut self,
+        negotiation: NegotiationType,
+        option: TelnetOption,
+        stream: &mut S,
+    ) -> io::Result<()> {
+        trace!(target: "telnet", "<< {:?} {:?}", negotiation, option);
+
+        if let Some(state) = self.options.get(&option) {
+            if state == &OptionState::Accept(negotiation) {
+                let (state, response_type) = match negotiation {
+                    NegotiationType::Do => (OptionState::Do, NegotiationType::Will),
+                    NegotiationType::Will => (OptionState::Will, NegotiationType::Do),
+                    _ => panic!("Impossible negotiation {:?} for {:?}", negotiation, option),
+                };
+                self.options.insert(option, state);
+
+                let response = TelnetEvent::Negotiate(response_type, option);
+                trace!(target: "telnet", ">> {:?}", response);
+                response.write_all(stream).await?;
+
+                return Ok(());
+            }
+        }
+
+        let response_type = match negotiation {
+            NegotiationType::Do => NegotiationType::Wont,
+            NegotiationType::Will => NegotiationType::Dont,
+            _ => panic!("Impossible negotiation {:?} for {:?}", negotiation, option),
+        };
+
+        let response = TelnetEvent::Negotiate(response_type, option);
+        trace!(target: "telnet", ">> {:?}", response);
+        response.write_all(stream).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct OptionsNegotiatorBuilder {
+    options: HashMap<TelnetOption, OptionState>,
+}
+
+impl OptionsNegotiatorBuilder {
+    pub fn build(self) -> OptionsNegotiator {
+        OptionsNegotiator {
+            options: self.options,
+        }
+    }
+
+    pub fn accept_do(mut self, option: TelnetOption) -> Self {
+        self.options
+            .insert(option, OptionState::Accept(NegotiationType::Do));
+        self
+    }
+
+    pub fn accept_will(mut self, option: TelnetOption) -> Self {
+        self.options
+            .insert(option, OptionState::Accept(NegotiationType::Will));
+        self
+    }
+}

--- a/src/transport/telnet/options/mod.rs
+++ b/src/transport/telnet/options/mod.rs
@@ -1,0 +1,77 @@
+use std::{collections::HashMap, io};
+
+use async_trait::async_trait;
+use tokio::io::AsyncWrite;
+
+use self::{
+    negotiator::{OptionsNegotiator, OptionsNegotiatorBuilder},
+    ttype::TermTypeOptionHandler,
+};
+
+use super::protocol::{NegotiationType, TelnetOption};
+
+pub mod negotiator;
+pub mod ttype;
+
+// NOTE: We need to Box the Stream type in order for TelnetOptionHandler to be object-safe.
+pub type DynWriteStream<'a> = Box<&'a mut (dyn AsyncWrite + Unpin + Send)>;
+
+#[async_trait]
+pub trait TelnetOptionHandler: Send {
+    fn option(&self) -> TelnetOption;
+    fn register(&self, negotiator: OptionsNegotiatorBuilder) -> OptionsNegotiatorBuilder;
+
+    async fn negotiate(
+        &mut self,
+        _negotiation: NegotiationType,
+        _stream: DynWriteStream<'_>,
+    ) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct TelnetOptionsManager {
+    negotiator: OptionsNegotiator,
+    handlers: HashMap<TelnetOption, Box<dyn TelnetOptionHandler>>,
+}
+
+impl Default for TelnetOptionsManager {
+    fn default() -> Self {
+        let mut negotiator_builder = OptionsNegotiatorBuilder::default();
+        let mut handlers: HashMap<TelnetOption, Box<dyn TelnetOptionHandler>> = Default::default();
+
+        // All handlers:
+        let all_handlers: Vec<Box<dyn TelnetOptionHandler>> =
+            vec![Box::new(TermTypeOptionHandler::default())];
+
+        // Register with the builder
+        for handler in all_handlers {
+            negotiator_builder = handler.register(negotiator_builder);
+            handlers.insert(handler.option(), handler);
+        }
+
+        let negotiator = negotiator_builder.build();
+        TelnetOptionsManager {
+            negotiator,
+            handlers,
+        }
+    }
+}
+
+impl TelnetOptionsManager {
+    pub async fn negotiate<S: AsyncWrite + Unpin + Send>(
+        &mut self,
+        negotiation: NegotiationType,
+        option: TelnetOption,
+        stream: &mut S,
+    ) -> io::Result<()> {
+        self.negotiator
+            .negotiate(negotiation, option, stream)
+            .await?;
+        if let Some(handler) = self.handlers.get_mut(&option) {
+            let wrapped: Box<&mut (dyn AsyncWrite + Unpin + Send)> = Box::new(stream);
+            handler.negotiate(negotiation, wrapped).await?;
+        }
+        Ok(())
+    }
+}

--- a/src/transport/telnet/options/negotiator.rs
+++ b/src/transport/telnet/options/negotiator.rs
@@ -3,9 +3,10 @@ use std::{collections::HashMap, io};
 use log::trace;
 use tokio::io::AsyncWrite;
 
-use crate::transport::telnet::processor::TelnetEvent;
-
-use super::protocol::{NegotiationType, TelnetOption};
+use crate::transport::telnet::{
+    processor::TelnetEvent,
+    protocol::{NegotiationType, TelnetOption},
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OptionState {
@@ -76,6 +77,7 @@ impl OptionsNegotiatorBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub fn accept_will(mut self, option: TelnetOption) -> Self {
         self.options
             .insert(option, OptionState::Accept(NegotiationType::Will));

--- a/src/transport/telnet/options/negotiator.rs
+++ b/src/transport/telnet/options/negotiator.rs
@@ -46,14 +46,29 @@ impl OptionsNegotiator {
         }
 
         let response_type = match negotiation {
-            NegotiationType::Do => NegotiationType::Wont,
-            NegotiationType::Will => NegotiationType::Dont,
-            _ => panic!("Impossible negotiation {:?} for {:?}", negotiation, option),
+            NegotiationType::Do => Some(NegotiationType::Wont),
+            NegotiationType::Will => Some(NegotiationType::Dont),
+            NegotiationType::Dont => {
+                if self.options.get(&option) == Some(&OptionState::Do) {
+                    self.options
+                        .insert(option, OptionState::Accept(NegotiationType::Do));
+                }
+                Some(NegotiationType::Wont)
+            }
+            NegotiationType::Wont => {
+                if self.options.get(&option) == Some(&OptionState::Will) {
+                    self.options
+                        .insert(option, OptionState::Accept(NegotiationType::Will));
+                }
+                None
+            }
         };
 
-        let response = TelnetEvent::Negotiate(response_type, option);
-        trace!(target: "telnet", ">> {:?}", response);
-        response.write_all(stream).await?;
+        if let Some(response_type) = response_type {
+            let response = TelnetEvent::Negotiate(response_type, option);
+            trace!(target: "telnet", ">> {:?}", response);
+            response.write_all(stream).await?;
+        }
 
         Ok(())
     }
@@ -82,5 +97,91 @@ impl OptionsNegotiatorBuilder {
         self.options
             .insert(option, OptionState::Accept(NegotiationType::Will));
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::task::Poll;
+
+    use bytes::BytesMut;
+
+    use super::*;
+
+    struct TestStream {
+        sent: BytesMut,
+    }
+
+    impl TestStream {
+        pub fn new() -> Self {
+            Self {
+                sent: BytesMut::default(),
+            }
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<Result<usize, io::Error>> {
+            self.sent.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), io::Error>> {
+            todo!()
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), io::Error>> {
+            todo!()
+        }
+    }
+
+    #[tokio::test]
+    async fn dont_after_do_test() -> io::Result<()> {
+        let mut handler = OptionsNegotiatorBuilder::default()
+            .accept_do(TelnetOption::TermType)
+            .build();
+
+        let mut stream = TestStream::new();
+
+        handler
+            .negotiate(NegotiationType::Do, TelnetOption::TermType, &mut stream)
+            .await?;
+
+        handler
+            .negotiate(NegotiationType::Dont, TelnetOption::TermType, &mut stream)
+            .await?;
+
+        let mut expected_stream = TestStream::new();
+        TelnetEvent::Negotiate(NegotiationType::Will, TelnetOption::TermType)
+            .write_all(&mut expected_stream)
+            .await?;
+        TelnetEvent::Negotiate(NegotiationType::Wont, TelnetOption::TermType)
+            .write_all(&mut expected_stream)
+            .await?;
+        assert_eq!(stream.sent, expected_stream.sent);
+
+        // If the server changes their mind, our state should be ready for that
+        expected_stream.sent.clear();
+        stream.sent.clear();
+        handler
+            .negotiate(NegotiationType::Do, TelnetOption::TermType, &mut stream)
+            .await?;
+
+        TelnetEvent::Negotiate(NegotiationType::Will, TelnetOption::TermType)
+            .write_all(&mut expected_stream)
+            .await?;
+        assert_eq!(stream.sent, expected_stream.sent);
+
+        Ok(())
     }
 }

--- a/src/transport/telnet/options/ttype.rs
+++ b/src/transport/telnet/options/ttype.rs
@@ -87,7 +87,7 @@ impl TermTypeOptionHandler {
             State::MttsBitVector => {
                 let mut bit_vector = 0;
 
-                if let Some(colors) = supports_color::on(supports_color::Stream::Stdout) {
+                if let Some(colors) = supports_color::on_cached(supports_color::Stream::Stdout) {
                     if colors.has_basic {
                         bit_vector += MTTS_ANSI;
                     }

--- a/src/transport/telnet/options/ttype.rs
+++ b/src/transport/telnet/options/ttype.rs
@@ -1,0 +1,86 @@
+use std::{env, io};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+
+use crate::transport::telnet::{
+    processor::TelnetEvent,
+    protocol::{NegotiationType, TelnetOption},
+};
+
+use super::{negotiator::OptionsNegotiatorBuilder, DynWriteStream, TelnetOptionHandler};
+
+enum State {
+    ClientName,
+    TermType,
+    MttsBitVector,
+}
+
+pub struct TermTypeOptionHandler {
+    state: State,
+}
+
+impl Default for TermTypeOptionHandler {
+    fn default() -> Self {
+        Self {
+            state: State::ClientName,
+        }
+    }
+}
+
+#[async_trait]
+impl TelnetOptionHandler for TermTypeOptionHandler {
+    fn option(&self) -> TelnetOption {
+        TelnetOption::TermType
+    }
+
+    fn register(&self, negotiator: OptionsNegotiatorBuilder) -> OptionsNegotiatorBuilder {
+        negotiator.accept_do(TelnetOption::TermType)
+    }
+
+    async fn negotiate(
+        &mut self,
+        negotiation: NegotiationType,
+        stream: DynWriteStream<'_>,
+    ) -> io::Result<()> {
+        match negotiation {
+            NegotiationType::Do => {
+                self.respond_with_state(stream).await?;
+                self.advance_state();
+            }
+            NegotiationType::Dont => {
+                self.reset();
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl TermTypeOptionHandler {
+    fn reset(&mut self) {
+        self.state = State::ClientName;
+    }
+
+    async fn respond_with_state(&self, mut stream: DynWriteStream<'_>) -> io::Result<()> {
+        let name = self.build_name();
+        let message = TelnetEvent::Subnegotiate(self.option(), name.freeze());
+        log::trace!(target: "telnet", ">> {:?}", message);
+        message.write_all(&mut stream).await
+    }
+
+    fn build_name(&self) -> BytesMut {
+        match self.state {
+            State::ClientName => "kodachi".into(),
+            State::TermType => env::var("TERM").unwrap_or("".to_string()).as_str().into(),
+            State::MttsBitVector => "MTTS 0".into(), // TODO
+        }
+    }
+
+    fn advance_state(&mut self) {
+        self.state = match self.state {
+            State::ClientName => State::TermType,
+            _ => State::MttsBitVector,
+        };
+    }
+}

--- a/src/transport/telnet/processor.rs
+++ b/src/transport/telnet/processor.rs
@@ -12,7 +12,7 @@ pub enum TelnetEvent {
     Data(Bytes),
     Command(TelnetCommand),
     Negotiate(NegotiationType, TelnetOption),
-    Subnegotiate(Bytes),
+    Subnegotiate(TelnetOption, Bytes),
 }
 
 impl TelnetEvent {
@@ -28,10 +28,11 @@ impl TelnetEvent {
                 stream.write_u8(negotiation.byte()).await?;
                 stream.write_u8(option.byte()).await
             }
-            TelnetEvent::Subnegotiate(mut bytes) => {
+            TelnetEvent::Subnegotiate(option, mut bytes) => {
                 stream.write_u8(IAC).await?;
                 stream.write_u8(SB).await?;
 
+                stream.write_u8(option.byte()).await?;
                 stream.write_all_buf(&mut bytes).await?;
 
                 stream.write_u8(IAC).await?;
@@ -139,7 +140,7 @@ impl TelnetProcessor {
                 (State::SubnegotiateIac, SE) => {
                     self.state = State::Data;
                     let data_end = i.checked_sub(1);
-                    let data = bytes.split_to(data_end.unwrap_or(0)).freeze();
+                    let mut data = bytes.split_to(data_end.unwrap_or(0)).freeze();
 
                     // Consume SE and IAC
                     bytes.get_u8();
@@ -147,7 +148,9 @@ impl TelnetProcessor {
                         bytes.get_u8();
                     }
 
-                    return Ok(Some(TelnetEvent::Subnegotiate(data)));
+                    let option_byte = data.get_u8();
+                    let option = TelnetOption::from_byte(option_byte);
+                    return Ok(Some(TelnetEvent::Subnegotiate(option, data)));
                 }
                 (State::SubnegotiateIac, _) => {
                     // Unexpected byte; I guess just consume it
@@ -261,9 +264,10 @@ mod tests {
 
         assert_eq!(
             processor.process_one(&mut buffer)?,
-            Some(TelnetEvent::Subnegotiate(Bytes::from(
-                &b"\x45\x01VARNAME\x02THE VALUE"[..]
-            )))
+            Some(TelnetEvent::Subnegotiate(
+                TelnetOption::MSDP,
+                Bytes::from(&b"\x01VARNAME\x02THE VALUE"[..])
+            ))
         );
 
         assert_eq!(processor.process_one(&mut buffer)?, None);
@@ -279,9 +283,10 @@ mod tests {
 
         assert_eq!(
             processor.process_one(&mut buffer)?,
-            Some(TelnetEvent::Subnegotiate(Bytes::from(
-                &b"\x45\x01VARNAME\x02THE\xFFVALUE"[..]
-            )))
+            Some(TelnetEvent::Subnegotiate(
+                TelnetOption::MSDP,
+                Bytes::from(&b"\x01VARNAME\x02THE\xFFVALUE"[..])
+            ))
         );
 
         assert_eq!(processor.process_one(&mut buffer)?, None);

--- a/src/transport/telnet/processor.rs
+++ b/src/transport/telnet/processor.rs
@@ -240,7 +240,7 @@ mod tests {
             processor.process_one(&mut buffer)?,
             Some(TelnetEvent::Negotiate(
                 NegotiationType::Will,
-                TelnetOption::Ttype
+                TelnetOption::TermType
             ))
         );
         assert_eq!(

--- a/src/transport/telnet/protocol.rs
+++ b/src/transport/telnet/protocol.rs
@@ -32,6 +32,13 @@ impl TelnetCommand {
             _ => TelnetCommand::Unknown(byte),
         }
     }
+
+    pub fn byte(&self) -> u8 {
+        match self {
+            TelnetCommand::GoAhead => GA,
+            TelnetCommand::Unknown(b) => *b,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,9 +59,18 @@ impl NegotiationType {
             _ => panic!("Not a negotiation type: {:?}", byte),
         }
     }
+
+    pub fn byte(&self) -> u8 {
+        match self {
+            NegotiationType::Will => WILL,
+            NegotiationType::Wont => WONT,
+            NegotiationType::Do => DO,
+            NegotiationType::Dont => DONT,
+        }
+    }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum TelnetOption {
     Ttype,
     Naws,
@@ -67,6 +83,14 @@ impl TelnetOption {
             options::TTYPE => TelnetOption::Ttype,
             options::NAWS => TelnetOption::Naws,
             _ => TelnetOption::Unknown(byte),
+        }
+    }
+
+    pub fn byte(&self) -> u8 {
+        match self {
+            TelnetOption::Ttype => options::TTYPE,
+            TelnetOption::Naws => options::NAWS,
+            TelnetOption::Unknown(b) => *b,
         }
     }
 }

--- a/src/transport/telnet/protocol.rs
+++ b/src/transport/telnet/protocol.rs
@@ -1,6 +1,3 @@
-// Go Ahead
-pub const GA: u8 = 249;
-
 pub const SE: u8 = 240;
 pub const SB: u8 = 250;
 pub const WILL: u8 = 251;
@@ -10,36 +7,6 @@ pub const DONT: u8 = 254;
 
 // Interpret As Command
 pub const IAC: u8 = 255;
-
-pub mod options {
-    // Terminal Type
-    pub const TTYPE: u8 = 24;
-
-    // Negotiate About Window Size
-    pub const NAWS: u8 = 31;
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TelnetCommand {
-    GoAhead,
-    Unknown(u8),
-}
-
-impl TelnetCommand {
-    pub fn from_byte(byte: u8) -> TelnetCommand {
-        match byte {
-            GA => TelnetCommand::GoAhead,
-            _ => TelnetCommand::Unknown(byte),
-        }
-    }
-
-    pub fn byte(&self) -> u8 {
-        match self {
-            TelnetCommand::GoAhead => GA,
-            TelnetCommand::Unknown(b) => *b,
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NegotiationType {
@@ -70,27 +37,52 @@ impl NegotiationType {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub enum TelnetOption {
-    Ttype,
-    Naws,
-    Unknown(u8),
+macro_rules! declare_type {
+    (
+        $type_name:ident {
+            $($name:ident => $byte_value_name:expr,)*
+        }
+    ) => {
+        #[allow(dead_code)]
+        #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+        pub enum $type_name {
+            $($name),*,
+            Unknown(u8),
+        }
+
+        impl $type_name {
+            #[allow(dead_code)]
+            pub fn from_byte(byte: u8) -> Self {
+                match byte {
+                    $($byte_value_name => $type_name::$name),*,
+                    _ => $type_name::Unknown(byte),
+                }
+            }
+
+            #[allow(dead_code)]
+            pub fn byte(&self) -> u8 {
+                match self {
+                    $($type_name::$name => $byte_value_name),*,
+                    $type_name::Unknown(byte) => *byte,
+                }
+            }
+        }
+    };
 }
 
-impl TelnetOption {
-    pub fn from_byte(byte: u8) -> Self {
-        match byte {
-            options::TTYPE => TelnetOption::Ttype,
-            options::NAWS => TelnetOption::Naws,
-            _ => TelnetOption::Unknown(byte),
-        }
-    }
+declare_type!(TelnetCommand {
+    GoAhead => 249,
+});
 
-    pub fn byte(&self) -> u8 {
-        match self {
-            TelnetOption::Ttype => options::TTYPE,
-            TelnetOption::Naws => options::NAWS,
-            TelnetOption::Unknown(b) => *b,
-        }
-    }
-}
+declare_type!(TelnetOption {
+    SuppressGoAhead => 3,
+    TermType => 24,
+    // Negotiate About Window Size
+    Naws => 31,
+    Charset => 42,
+    MSDP => 69,
+    MCCP2 => 86,
+    MCCP3 => 87,
+    MSP => 90,
+    GMCP => 201,
+});

--- a/src/transport/telnet/protocol.rs
+++ b/src/transport/telnet/protocol.rs
@@ -75,6 +75,7 @@ declare_type!(TelnetCommand {
 });
 
 declare_type!(TelnetOption {
+    Echo => 1,
     SuppressGoAhead => 3,
     TermType => 24,
     // Negotiate About Window Size


### PR DESCRIPTION
A couple things this does in particular:

- Adds a `write_all()` method to `TelnetEvent` to make it easy to construct and send Telnet negotiations (and subnegotiations!) from option handlers
- Updates our `TelnetOption` and `TelnetCommand` enums to be generated via a macro that adds `byte()` and `from_byte()` methods in an easy way.
- Adds some basic logging support, which can be revealed similar to the `debug` nodejs library using the `DEBUG` env var when launching the RPC program
- Actually implements the MTTS protocol

Details:

- Add basic telnet option negotiation and debug logging support
- Use a macro to declare TelnetOption values
- Add initial ttype handler implementation + prepare to support others
- Fix handling of Dont negotiations after a Do
- Fix: responding with "Wont" to a second "Do" for the same option
- Fix ttype protocol subnegotiation
- Implement the MTTS bitvector
