### PR TITLE
Add initial support for Aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Daniel Leong <me@dhleong.net>"]
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.23.0", features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "sync"] }
+tokio = { version = "1.23.0", features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-native-tls = "0.3.0"
 async-trait = "0.1.59"
 flate2 = "1.0.25"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ it can be reused with whatever editors support embedding a terminal window.
 
 - [x] Triggers
 - [x] Prompts
-- [ ] Aliases
+- [x] Aliases
 - [x] Intelligent auto-completion (WIP)
 - [x] Input history management
 - [x] Common MUD protocols: MCCP2 (more to come)

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -1,8 +1,9 @@
 ---@alias KodachiRequest { type: string }
 
+---@alias AliasMatchedNotification { type: "'AliasMatched'", id: number, connection_id: number, handler_id: number, context: table }
 ---@alias TriggerMatchedNotification { type: "'TriggerMatched'", connection_id: number, handler_id: number, context: table }
 ---@alias DisconnectedNotification { type: "'Disconnected'", connection_id: number  }
----@alias KodachiNotification TriggerMatchedNotification | DisconnectedNotification
+---@alias KodachiNotification AliasMatchedNotification | TriggerMatchedNotification | DisconnectedNotification
 
 local DEFAULT_BLOCKING_TIMEOUT = 500
 

--- a/lua/kodachi/socket.lua
+++ b/lua/kodachi/socket.lua
@@ -1,6 +1,6 @@
 ---@alias KodachiRequest { type: string }
 
----@alias AliasMatchedNotification { type: "'AliasMatched'", id: number, connection_id: number, handler_id: number, context: table }
+---@alias AliasMatchedNotification { type: "'HandleAliasMatch'", id: number, connection_id: number, handler_id: number, context: table }
 ---@alias TriggerMatchedNotification { type: "'TriggerMatched'", connection_id: number, handler_id: number, context: table }
 ---@alias DisconnectedNotification { type: "'Disconnected'", connection_id: number  }
 ---@alias KodachiNotification AliasMatchedNotification | TriggerMatchedNotification | DisconnectedNotification

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -177,7 +177,6 @@ function KodachiState:_alias_handlers(socket)
                 type = 'AliasMatchHandled',
                 request_id = message.id,
                 handler_id = message.handler_id,
-                context = message.context,
                 replacement = result,
               }
             end

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -16,6 +16,7 @@ local with_socket = util.with_socket
 ---@field _events any|nil
 ---@field _mappings any
 ---@field _prompts PromptsManager|nil
+---@field _aliases Handlers|nil
 ---@field _triggers Handlers|nil
 local KodachiState = {}
 
@@ -28,6 +29,11 @@ end
 
 function KodachiState:cleanup()
   local cleared_any = false
+  if self._aliases then
+    self._aliases:clear()
+    cleared_any = true
+  end
+
   if self._triggers then
     self._triggers:clear()
     cleared_any = true
@@ -89,6 +95,30 @@ function KodachiState:on(event, handler)
 end
 
 ---@param matcher MatcherSpec|string
+function KodachiState:alias(matcher, handler)
+  matcher = matchers.inflate(matcher)
+  return with_socket(self, function(socket)
+    if type(handler) == "string" then
+      socket:request {
+        type = "RegisterSimpleAlias",
+        connection_id = self.connection_id,
+        matcher = matcher,
+        replacement_pattern = handler,
+      }
+    else
+      local aliases = self:_alias_handlers(socket)
+      local id = aliases:insert(handler)
+      socket:request {
+        type = "RegisterAlias",
+        connection_id = self.connection_id,
+        matcher = matcher,
+        handler_id = id,
+      }
+    end
+  end)
+end
+
+---@param matcher MatcherSpec|string
 ---@param handler fun(context)|nil If provided, a fn called with the same params as a trigger() handler,
 ---and whose return value will be used as the prompt content
 function KodachiState:prompt(matcher, handler)
@@ -128,6 +158,41 @@ function KodachiState:send(text)
       text = text,
     }
   end)
+end
+
+---@param socket Socket
+function KodachiState:_alias_handlers(socket)
+  local aliases = self._aliases
+  if not aliases then
+    local new_aliases = Handlers:new()
+    self._aliases = new_aliases
+    socket:listen(function(message)
+      if message.type == 'AliasMatched' and message.connection_id == self.connection_id then
+        local matched_handler = self._aliases:get(message.handler_id)
+        if matched_handler then
+          vim.schedule(function()
+            local result = matched_handler(message.context)
+            if type(result) == 'string' then
+              socket:notify {
+                type = 'AliasMatchHandled',
+                request_id = message.id,
+                handler_id = message.handler_id,
+                context = message.context,
+                replacement = result,
+              }
+            end
+          end)
+        else
+          vim.schedule(function()
+            print('WARNING: Alias handler missing...')
+          end)
+        end
+      end
+    end)
+    return new_aliases
+  end
+
+  return aliases
 end
 
 ---@param socket Socket

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -167,7 +167,7 @@ function KodachiState:_alias_handlers(socket)
     local new_aliases = Handlers:new()
     self._aliases = new_aliases
     socket:listen(function(message)
-      if message.type == 'AliasMatched' and message.connection_id == self.connection_id then
+      if message.type == 'HandleAliasMatch' and message.connection_id == self.connection_id then
         local matched_handler = self._aliases:get(message.handler_id)
         if matched_handler then
           vim.schedule(function()

--- a/lua/kodachi/states.lua
+++ b/lua/kodachi/states.lua
@@ -1,4 +1,4 @@
-local KodachiState = require'kodachi.state'
+local KodachiState = require 'kodachi.state'
 
 local M = {
   states = {},
@@ -36,11 +36,11 @@ function M.current_connected()
 end
 
 setmetatable(M, {
-  __index = function (_, bufnr)
+  __index = function(_, bufnr)
     return M.states[bufnr]
   end,
 
-  __newindex = function (_, bufnr, state)
+  __newindex = function(_, bufnr, state)
     if M.states[bufnr] or M.states[state.bufnr] then
       M.states[bufnr] = state
     end

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -18,6 +18,7 @@ pub enum Outgoing {
 
 #[derive(Default, Clone)]
 pub struct ConnectionState {
+    pub send_processor: Arc<Mutex<TextProcessor>>,
     pub processor: Arc<Mutex<TextProcessor>>,
     pub completions: Arc<Mutex<Completions>>,
     pub sent: Arc<Mutex<History<String>>>,
@@ -76,6 +77,14 @@ impl Connections {
     pub fn get_state(&mut self, id: Id) -> Option<ConnectionState> {
         if let Some(conn) = self.connections.get(&id) {
             Some(conn.state.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_send_processor(&mut self, id: Id) -> Option<Arc<Mutex<TextProcessor>>> {
+        if let Some(conn) = self.connections.get(&id) {
+            Some(conn.state.send_processor.clone())
         } else {
             None
         }

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -8,7 +8,10 @@ use tokio::sync::mpsc;
 use crate::cli::ui::UiState;
 
 use super::{
-    completion::completions::Completions, history::History, processing::text::TextProcessor, Id,
+    completion::completions::Completions,
+    history::History,
+    processing::{send::SendTextProcessor, text::TextProcessor},
+    Id,
 };
 
 pub enum Outgoing {
@@ -18,7 +21,7 @@ pub enum Outgoing {
 
 #[derive(Default, Clone)]
 pub struct ConnectionState {
-    pub send_processor: Arc<Mutex<TextProcessor>>,
+    pub send_processor: Arc<tokio::sync::Mutex<SendTextProcessor>>,
     pub processor: Arc<Mutex<TextProcessor>>,
     pub completions: Arc<Mutex<Completions>>,
     pub sent: Arc<Mutex<History<String>>>,
@@ -82,7 +85,10 @@ impl Connections {
         }
     }
 
-    pub fn get_send_processor(&mut self, id: Id) -> Option<Arc<Mutex<TextProcessor>>> {
+    pub fn get_send_processor(
+        &mut self,
+        id: Id,
+    ) -> Option<Arc<tokio::sync::Mutex<SendTextProcessor>>> {
         if let Some(conn) = self.connections.get(&id) {
             Some(conn.state.send_processor.clone())
         } else {

--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -42,7 +42,7 @@ pub enum MatchResult {
 
 #[derive(Debug)]
 pub struct Matcher {
-    options: MatcherOptions,
+    pub options: MatcherOptions,
     pattern: Regex,
 }
 

--- a/src/app/processing/mod.rs
+++ b/src/app/processing/mod.rs
@@ -1,2 +1,3 @@
 pub mod ansi;
+pub mod send;
 pub mod text;

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -1,8 +1,13 @@
 use std::{future::Future, io, pin::Pin};
 
+use async_trait::async_trait;
+
 use crate::{
     app::matchers::{MatchResult, Matcher},
-    daemon::notifications::MatchContext,
+    daemon::{
+        notifications::{DaemonNotification, MatchContext},
+        responses::DaemonResponse,
+    },
 };
 
 use super::ansi::Ansi;
@@ -22,6 +27,11 @@ type MatchHandler = dyn Fn(MatchContext) -> Pin<Box<dyn Future<Output = io::Resu
 struct RegisteredMatcher {
     matcher: Matcher,
     on_match: Box<MatchHandler>,
+}
+
+#[async_trait]
+pub trait SendTextProcessorOutputReceiver {
+    async fn request(&mut self, request: DaemonNotification) -> io::Result<DaemonResponse>;
 }
 
 #[derive(Default)]

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -55,7 +55,6 @@ impl SendTextProcessor {
         let mut result = input;
 
         for _ in 0..MAX_RECURSION {
-            println!("process {}", result);
             match self.process_once(result).await? {
                 ProcessResult::Unchanged(final_result) => {
                     // Nothing more to replace!

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -45,6 +45,10 @@ impl SendTextProcessor {
         R: 'static + (Fn(MatchContext) -> F) + Send + Sync,
         F: 'static + Future<Output = io::Result<ProcessResult>> + Send + Sync,
     {
+        if matcher.options.consume {
+            panic!("Matcher ({:?}) is unexpectedly `consume`", matcher);
+        }
+
         self.matchers.push(RegisteredMatcher {
             matcher,
             on_match: Box::new(move |context| Box::pin(on_match(context))),

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -1,0 +1,140 @@
+use std::{future::Future, io, pin::Pin};
+
+use crate::{
+    app::matchers::{MatchResult, Matcher},
+    daemon::notifications::MatchContext,
+};
+
+use super::ansi::Ansi;
+
+const MAX_RECURSION: usize = 100;
+
+pub enum ProcessResult {
+    Unchanged(String),
+    ReplaceWith(String),
+    Stop,
+}
+
+type MatchHandler =
+    dyn Fn(MatchContext) -> Pin<Box<dyn Future<Output = io::Result<ProcessResult>>>>;
+// type MatchHandler = dyn Fn(MatchContext) -> io::Result<ProcessResult>;
+
+struct RegisteredMatcher {
+    matcher: Matcher,
+    on_match: Box<MatchHandler>,
+}
+
+#[derive(Default)]
+pub struct SendTextProcessor {
+    matchers: Vec<RegisteredMatcher>,
+}
+
+impl SendTextProcessor {
+    pub fn register_matcher<
+        R: 'static + Fn(MatchContext) -> Pin<Box<dyn Future<Output = io::Result<ProcessResult>>>>,
+    >(
+        &mut self,
+        matcher: Matcher,
+        on_match: R,
+    ) {
+        self.matchers.push(RegisteredMatcher {
+            matcher,
+            on_match: Box::new(on_match),
+        })
+    }
+
+    pub async fn process(&self, input: String) -> io::Result<Option<String>> {
+        let mut result = input;
+
+        for _ in 0..MAX_RECURSION {
+            match self.process_once(result).await? {
+                ProcessResult::Unchanged(final_result) => {
+                    // Nothing more to replace!
+                    return Ok(Some(final_result));
+                }
+                ProcessResult::ReplaceWith(changed) => {
+                    result = changed;
+                }
+                ProcessResult::Stop => {
+                    return Ok(None);
+                }
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Infinite loop detected",
+        ))
+    }
+
+    async fn process_once(&self, input: String) -> io::Result<ProcessResult> {
+        // TODO The conversion from String <-> Ansi could be cheaper...
+        let mut to_match: Ansi = input.into();
+        for matcher in &self.matchers {
+            match matcher.matcher.try_match(to_match) {
+                MatchResult::Ignored(ignored) => to_match = ignored,
+                MatchResult::Matched { context, .. } => {
+                    if let Some(replaced) = self.process_match(matcher, context).await? {
+                        to_match = replaced.into();
+                    } else {
+                        return Ok(ProcessResult::Stop);
+                    }
+                }
+            }
+        }
+        Ok(ProcessResult::Unchanged(to_match.strip_ansi().to_string()))
+    }
+
+    async fn process_match(
+        &self,
+        matcher: &RegisteredMatcher,
+        mut context: MatchContext,
+    ) -> io::Result<Option<String>> {
+        let result = (matcher.on_match)(context.clone());
+        match result.await? {
+            ProcessResult::Stop => Ok(None),
+            ProcessResult::Unchanged(s) => Ok(Some(s)),
+            ProcessResult::ReplaceWith(replacement) => {
+                let mut input = context.take_full_match().plain;
+                input.replace_range(context.full_match_range, &replacement);
+                Ok(Some(input))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::matchers::MatcherSpec;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn single_replacement_test() -> io::Result<()> {
+        let mut processor = SendTextProcessor::default();
+        processor.register_matcher(
+            MatcherSpec::Regex {
+                options: Default::default(),
+                source: "activate (.*)".to_string(),
+            }
+            .try_into()
+            .unwrap(),
+            |context| {
+                Box::pin(async move {
+                    Ok(ProcessResult::ReplaceWith(format!(
+                        "yell For the Honor of Grayskull, {}!",
+                        context.indexed[&1].plain
+                    )))
+                })
+            },
+        );
+
+        let result = processor.process("activate sword".to_string()).await?;
+        assert_eq!(
+            result.expect("Processing was unexpectedly stopped"),
+            "yell For the Honor of Grayskull, sword!"
+        );
+
+        Ok(())
+    }
+}

--- a/src/daemon/channel.rs
+++ b/src/daemon/channel.rs
@@ -56,6 +56,7 @@ impl Channel {
         }
     }
 
+    #[allow(unused)]
     pub fn notify(&mut self, payload: Notification) {
         self.writer.write_json(&payload).unwrap();
     }
@@ -110,7 +111,7 @@ impl ConnectionChannel {
                         return Ok(response.payload);
                     }
                 }
-                Ok(err) => {
+                Ok(_err) => {
                     // Probably a RecvError meaning the sender is gone. This.. shouldn't happen
                     return Err(io::ErrorKind::TimedOut.into());
                 }

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -44,6 +44,12 @@ pub enum ClientRequest {
         params: CompletionParams,
     },
 
+    RegisterAlias {
+        connection_id: Id,
+        matcher: MatcherSpec,
+        handler_id: Id,
+    },
+
     RegisterTrigger {
         connection_id: Id,
         matcher: MatcherSpec,

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod complete_composer;
 pub mod connect;
 pub mod disconnect;
 pub mod get_history;
+pub mod register_alias;
 pub mod register_prompt;
 pub mod register_trigger;
 pub mod scroll_history;

--- a/src/daemon/handlers/send.rs
+++ b/src/daemon/handlers/send.rs
@@ -47,7 +47,7 @@ pub async fn handle(channel: Channel, mut state: LockableState, connection_id: I
     // Enqueue the processed text to be sent
     let outbox = state.lock().unwrap().connections.get_outbox(connection_id);
     let sent = if let Some(outbox) = outbox {
-        outbox.send(Outgoing::Text(to_send.clone())).await.is_ok()
+        outbox.send(Outgoing::Text(to_send)).await.is_ok()
     } else {
         false
     };

--- a/src/daemon/handlers/send.rs
+++ b/src/daemon/handlers/send.rs
@@ -3,7 +3,30 @@ use crate::{
     daemon::{channel::Channel, responses::DaemonResponse},
 };
 
+async fn process_aliases(
+    channel: Channel,
+    state: LockableState,
+    connection_id: Id,
+    text: String,
+) -> (Channel, String) {
+    let processor_ref = if let Some(reference) = state
+        .clone()
+        .lock()
+        .unwrap()
+        .connections
+        .get_send_processor(connection_id)
+    {
+        reference.clone()
+    } else {
+        return (channel, text);
+    };
+
+    (channel, text)
+}
+
 pub async fn handle(channel: Channel, mut state: LockableState, connection_id: Id, text: String) {
+    let (channel, text) = process_aliases(channel, state.clone(), connection_id, text).await;
+
     let outbox = state.lock().unwrap().connections.get_outbox(connection_id);
     let sent = if let Some(outbox) = outbox {
         outbox.send(Outgoing::Text(text.clone())).await.is_ok()

--- a/src/daemon/handlers/send.rs
+++ b/src/daemon/handlers/send.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use crate::{
     app::{connections::Outgoing, Id, LockableState},
     daemon::{channel::Channel, responses::DaemonResponse},
@@ -8,7 +10,7 @@ async fn process_aliases(
     state: LockableState,
     connection_id: Id,
     text: String,
-) -> (Channel, String) {
+) -> (Channel, io::Result<Option<String>>) {
     let processor_ref = if let Some(reference) = state
         .clone()
         .lock()
@@ -18,26 +20,45 @@ async fn process_aliases(
     {
         reference.clone()
     } else {
-        return (channel, text);
+        return (channel, Ok(Some(text)));
     };
 
-    (channel, text)
+    let processor = processor_ref.lock().await;
+    let result = processor.process(text).await;
+
+    (channel, result)
 }
 
 pub async fn handle(channel: Channel, mut state: LockableState, connection_id: Id, text: String) {
-    let (channel, text) = process_aliases(channel, state.clone(), connection_id, text).await;
+    let (channel, text_result) =
+        process_aliases(channel, state.clone(), connection_id, text.clone()).await;
+    let to_send = match text_result {
+        Ok(Some(text)) => text,
 
+        Ok(None) => return, // Input consumed; nothing to send
+        Err(err) => {
+            channel.respond(DaemonResponse::ErrorResult {
+                error: err.to_string(),
+            });
+            return;
+        }
+    };
+
+    // Enqueue the processed text to be sent
     let outbox = state.lock().unwrap().connections.get_outbox(connection_id);
     let sent = if let Some(outbox) = outbox {
-        outbox.send(Outgoing::Text(text.clone())).await.is_ok()
+        outbox.send(Outgoing::Text(to_send.clone())).await.is_ok()
     } else {
         false
     };
 
+    // After sending successfully, process the input text
     if let Some(connection) = state.lock().unwrap().connections.get_state(connection_id) {
+        // Add to send history
         let mut sent = connection.sent.lock().unwrap();
         sent.insert(text.clone());
 
+        // Process for completions
         let mut completions = connection.completions.lock().unwrap();
         completions.process_outgoing(text);
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -8,6 +8,7 @@ mod commands;
 mod handlers;
 pub mod notifications;
 pub mod protocol;
+pub mod requests;
 pub mod responses;
 
 use crate::app::LockableState;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -16,7 +16,7 @@ use crate::app::LockableState;
 use self::{
     channel::{Channel, ChannelSource},
     commands::{ClientNotification, ClientRequest},
-    protocol::Request,
+    protocol::{Request, RequestIdGenerator},
 };
 
 fn launch<T>(handler: T)
@@ -36,7 +36,8 @@ pub async fn daemon<TInput: BufRead, TResponse: 'static + Write + Send>(
 ) -> io::Result<()> {
     let shared_state = LockableState::default();
     let (to_listeners, _) = tokio::sync::broadcast::channel(1);
-    let channels = ChannelSource::new(Box::new(response), to_listeners.clone());
+    let request_ids = RequestIdGenerator::default();
+    let channels = ChannelSource::new(Box::new(response), request_ids, to_listeners.clone());
 
     for read in input.lines() {
         let raw_json = read?;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -116,6 +116,20 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
             ));
         }
 
+        ClientRequest::RegisterAlias {
+            connection_id,
+            matcher,
+            handler_id,
+        } => {
+            tokio::spawn(handlers::register_alias::handle(
+                channel,
+                state,
+                connection_id,
+                matcher,
+                handler_id,
+            ));
+        }
+
         ClientRequest::RegisterPrompt {
             connection_id: connection,
             matcher,

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::app::{processing::ansi::Ansi, Id};
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct MatchedText {
     #[serde(skip_serializing)]
     pub raw: Ansi,
@@ -22,7 +22,7 @@ impl MatchedText {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct MatchContext {
     pub named: HashMap<String, MatchedText>,
     pub indexed: HashMap<usize, MatchedText>,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 pub mod cursors;
 
@@ -53,6 +56,20 @@ pub enum Notification {
     },
 }
 
+#[derive(Clone, Default)]
+pub struct RequestIdGenerator {
+    next_id: Arc<Mutex<Id>>,
+}
+
+impl RequestIdGenerator {
+    pub async fn next(&mut self) -> Id {
+        let mut lock = self.next_id.lock().await;
+        let next_id = *lock;
+        *lock += 1;
+        return next_id;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,6 +103,29 @@ mod tests {
                 assert_eq!(connection_id, 42);
             }
             _ => assert!(false, "Expected Disconnect Rquest"),
+        }
+    }
+
+    mod reqest_id_generator_tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn request_id_generator_test() {
+            let mut generator = RequestIdGenerator::default();
+            let zero = generator.next().await;
+            let one = generator.next().await;
+            assert_eq!(zero, 0);
+            assert_eq!(one, 1);
+        }
+
+        #[tokio::test]
+        async fn cloning_test() {
+            let mut generator_one = RequestIdGenerator::default();
+            let mut clone = generator_one.clone();
+            let zero = clone.next().await;
+            let one = generator_one.next().await;
+            assert_eq!(zero, 0);
+            assert_eq!(one, 1);
         }
     }
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -7,6 +7,7 @@ use crate::app::Id;
 use super::{
     commands::{ClientNotification, ClientRequest},
     notifications::DaemonNotification,
+    requests::ServerRequest,
     responses::DaemonResponse,
 };
 
@@ -14,7 +15,7 @@ use super::{
 #[serde(untagged)]
 pub enum Request {
     ForResponse {
-        id: u64,
+        id: Id,
 
         #[serde(flatten)]
         payload: ClientRequest,
@@ -39,6 +40,14 @@ pub enum Notification {
 
         #[serde(flatten)]
         notification: DaemonNotification,
+    },
+
+    ServerRequest {
+        id: Id,
+        connection_id: Id,
+
+        #[serde(flatten)]
+        payload: ServerRequest,
     },
 }
 

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -8,7 +8,7 @@ use super::{
     commands::{ClientNotification, ClientRequest},
     notifications::DaemonNotification,
     requests::ServerRequest,
-    responses::DaemonResponse,
+    responses::{DaemonResponse, ResponseToServerRequest},
 };
 
 #[derive(Deserialize)]
@@ -20,6 +20,8 @@ pub enum Request {
         #[serde(flatten)]
         payload: ClientRequest,
     },
+
+    Response(ResponseToServerRequest),
 
     Notification(ClientNotification),
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -64,9 +64,10 @@ pub struct RequestIdGenerator {
 impl RequestIdGenerator {
     pub async fn next(&mut self) -> Id {
         let mut lock = self.next_id.lock().await;
-        let next_id = *lock;
-        *lock += 1;
-        return next_id;
+        let id = *lock;
+        let (next_id, _) = id.overflowing_add(1);
+        *lock = next_id;
+        return id;
     }
 }
 

--- a/src/daemon/requests.rs
+++ b/src/daemon/requests.rs
@@ -1,0 +1,14 @@
+use serde::Serialize;
+
+use crate::app::Id;
+
+use super::notifications::MatchContext;
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+pub enum ServerRequest {
+    HandleAliasMatch {
+        handler_id: Id,
+        context: MatchContext,
+    },
+}

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -40,7 +40,6 @@ pub enum ClientResponse {
 
 #[derive(Clone, Deserialize)]
 pub struct ResponseToServerRequest {
-    #[serde(rename = "id")]
     pub request_id: Id,
 
     #[serde(flatten)]

--- a/src/daemon/responses.rs
+++ b/src/daemon/responses.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::app::Id;
 
@@ -30,4 +30,19 @@ pub enum DaemonResponse {
         new_content: String,
         cursor: Option<HistoryCursor>,
     },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClientResponse {
+    AliasMatchHandled { replacement: Option<String> },
+}
+
+#[derive(Clone, Deserialize)]
+pub struct ResponseToServerRequest {
+    #[serde(rename = "id")]
+    pub request_id: Id,
+
+    #[serde(flatten)]
+    pub payload: ClientResponse,
 }


### PR DESCRIPTION
This adds initial support for aliases, with functional replacement happening over RPC. This looks like:

```lua
s:alias(m.regex '^activate (.*)', function (context)
  return 'say "Activate ' .. context.indexed[1].plain .. '"'
end)
```

Future work will add support for simple patterns for common cases, enabling eg:

```lua
s:alias('^activate $1', 'say "Activate $1"')
```

Returning `nil` from an alias replacement function will prevent anything from being sent. This can be useful if you need to `s:send()` directly yourself, for whatever reason.

- Prepare lua API for supporting aliases
- Prepare rough, initial support for async match replacement handling
- Simplify register_matcher's API
- Integrate SendTextProcessor into the send handler
- Scaffold out support for making RPC requests to the client for Aliases
- Update client's name from AliasMatched -> HandleAliasMatch
- Implement server -> client RPC requests; use with RegisterAlias
- Wire up RegisterAlias
- Fix: AliasMatchHandled not parseable as sent
