### PR TITLE
Add initial support for receiving MSDP events

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ it can be reused with whatever editors support embedding a terminal window.
 - [x] Aliases
 - [x] Intelligent auto-completion
 - [x] Input history management
-- [x] Common MUD protocols: MCCP2 (more to come)
+- [x] Common MUD protocols: [MTTS][mtts], [MCCP2][mccp2], [MSDP][msdp]
+- [x] Secure connections over TLS
 
 
 ## How?
@@ -100,3 +101,6 @@ require 'null-ls'.setup {
 [rust]: https://www.rust-lang.org
 [plug]: https://github.com/junegunn/vim-plug
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
+[mtts]: https://mudhalla.net/tintin/protocols/mtts/
+[mccp2]: https://tintin.mudhalla.net/protocols/mccp/
+[msdp]: https://tintin.mudhalla.net/protocols/msdp/

--- a/lua/kodachi/events.lua
+++ b/lua/kodachi/events.lua
@@ -1,0 +1,31 @@
+---@param event_spec table
+local function event_data_matches(event_spec, message)
+  if event_spec[1] ~= message.ns then
+    return false
+  end
+
+  if #event_spec == 2 and event_spec[2] ~= message.name then
+    return false
+  end
+
+  return true
+end
+
+local M = {}
+
+---@return string, fun(any)
+function M.wrap(event, handler)
+  if type(event) == "table" then
+    local function wrapped(message)
+      if event_data_matches(event, message) then
+        handler(message.payload, message)
+      end
+    end
+
+    return 'event', wrapped
+  else
+    return event, handler
+  end
+end
+
+return M

--- a/lua/kodachi/events.lua
+++ b/lua/kodachi/events.lua
@@ -1,4 +1,6 @@
----@param event_spec table
+---@alias EventSpec table
+
+---@param event_spec EventSpec
 local function event_data_matches(event_spec, message)
   if event_spec[1] ~= message.ns then
     return false

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -34,6 +34,12 @@ function KodachiState:cleanup()
     cleared_any = true
   end
 
+  if self._events then
+    -- NOTE: We don't need to set cleared_any because the server is not tracking
+    -- any state for us for events.
+    self._events = nil
+  end
+
   if self._triggers then
     self._triggers:clear()
     cleared_any = true
@@ -91,7 +97,11 @@ function KodachiState:on(event, handler)
     end
   end
 
-  self._events[event] = handler
+  if not self._events[event] then
+    self._events[event] = {}
+  end
+
+  table.insert(self._events[event], handler)
 end
 
 ---@param matcher MatcherSpec|string

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -1,3 +1,4 @@
+local events = require 'kodachi.events'
 local Handlers = require 'kodachi.handlers'
 local matchers = require 'kodachi.matchers'
 local PromptsManager = require 'kodachi.prompts'
@@ -75,14 +76,14 @@ function KodachiState:map(lhs, rhs)
   )
 end
 
----Register an event handler
+---Register a generic handler for any RPC event
 ---@param event KodachiEvent
 function KodachiState:on(event, handler)
   if not self._events then
     self._events = {}
     self.socket:listen(function(message)
       local events = self._events[string.lower(message.type)]
-      if events then
+      if events and self.connection_id == message.connection_id then
         vim.schedule(function()
           for _, saved_handler in ipairs(events) do
             saved_handler(message)
@@ -101,6 +102,7 @@ function KodachiState:on(event, handler)
     self._events[event] = {}
   end
 
+  local event, handler = events.wrap(event, handler)
   table.insert(self._events[event], handler)
 end
 

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -36,6 +36,11 @@ pub async fn process_connection<T: Transport, R: ProcessorOutputReceiver>(
 
                     receiver.end_chunk()?;
                 },
+
+                TransportEvent::Event(data) => {
+                    receiver.notification(DaemonNotification::Event(data))?;
+                },
+
                 TransportEvent::Nop => {},
             },
 

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, ops::Range};
 
 use serde::Serialize;
 
-use crate::app::{processing::ansi::Ansi, Id};
+use crate::{
+    app::{processing::ansi::Ansi, Id},
+    transport::EventData,
+};
 
 #[derive(Clone, Serialize)]
 pub struct MatchedText {
@@ -46,4 +49,5 @@ pub enum DaemonNotification {
         handler_id: Id,
         context: MatchContext,
     },
+    Event(EventData),
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,4 @@
+pub mod readable;
 mod uri;
 pub mod writable;
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,4 @@
 mod uri;
+pub mod writable;
 
 pub use uri::Uri;

--- a/src/net/readable.rs
+++ b/src/net/readable.rs
@@ -1,0 +1,7 @@
+use std::io::{self, BufRead};
+
+pub trait Readable {
+    fn read<S: BufRead>(stream: &mut S) -> io::Result<Self>
+    where
+        Self: Sized;
+}

--- a/src/net/writable.rs
+++ b/src/net/writable.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};

--- a/src/net/writable.rs
+++ b/src/net/writable.rs
@@ -1,0 +1,32 @@
+use std::io::{self, Write};
+
+use async_trait::async_trait;
+use bytes::{BufMut, Bytes, BytesMut};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+#[async_trait]
+pub trait ObjectWriteStream {
+    async fn write_object<T: Writable + Send>(&mut self, object: T) -> io::Result<()>;
+}
+
+pub trait Writable {
+    fn write<S: Write>(self, stream: &mut S) -> io::Result<()>;
+
+    fn into_bytes(self) -> Bytes
+    where
+        Self: Sized,
+    {
+        let mut writer = BytesMut::default().writer();
+        self.write(&mut writer)
+            .expect("Unexpected IO error writing to BytesMut");
+        writer.into_inner().freeze()
+    }
+}
+
+#[async_trait]
+impl<T: AsyncWrite + Unpin + Send> ObjectWriteStream for T {
+    async fn write_object<O: Writable + Send>(&mut self, object: O) -> io::Result<()> {
+        let mut bytes = object.into_bytes();
+        self.write_all_buf(&mut bytes).await
+    }
+}

--- a/src/net/writable.rs
+++ b/src/net/writable.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,7 +1,8 @@
-use std::io;
+use std::{collections::HashMap, io};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use serde::Serialize;
 
 use crate::net::Uri;
 
@@ -9,8 +10,24 @@ use self::telnet::TelnetTransport;
 
 pub mod telnet;
 
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum TransportEventValue {
+    String(String),
+    Vec(Vec<TransportEventValue>),
+    Map(HashMap<String, TransportEventValue>),
+}
+
+#[derive(Clone, Serialize)]
+pub struct EventData {
+    ns: String,
+    name: String,
+    payload: Option<TransportEventValue>,
+}
+
 pub enum TransportEvent {
     Data(Bytes),
+    Event(EventData),
     Nop,
 }
 

--- a/src/transport/telnet/options/mod.rs
+++ b/src/transport/telnet/options/mod.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use tokio::io::AsyncWrite;
 
 use self::{
+    msdp::MsdpOptionHandler,
     negotiator::{OptionsNegotiator, OptionsNegotiatorBuilder},
     ttype::TermTypeOptionHandler,
 };
@@ -12,6 +13,7 @@ use self::{
 use super::protocol::{NegotiationType, TelnetOption};
 
 pub mod mccp;
+pub mod msdp;
 pub mod negotiator;
 pub mod ttype;
 
@@ -46,9 +48,11 @@ impl Default for TelnetOptionsManager {
         let mut negotiator_builder = OptionsNegotiatorBuilder::default();
         let mut handlers: HashMap<TelnetOption, Box<dyn TelnetOptionHandler>> = Default::default();
 
+        let (msdp, _) = MsdpOptionHandler::new();
+
         // All handlers:
         let all_handlers: Vec<Box<dyn TelnetOptionHandler>> =
-            vec![Box::new(TermTypeOptionHandler::default())];
+            vec![Box::new(TermTypeOptionHandler::default()), Box::new(msdp)];
 
         // Register with the builder
         for handler in all_handlers {

--- a/src/transport/telnet/options/msdp.rs
+++ b/src/transport/telnet/options/msdp.rs
@@ -1,0 +1,120 @@
+use std::{collections::HashMap, io};
+
+use async_trait::async_trait;
+
+use crate::{
+    net::writable::{ObjectWriteStream, Writable},
+    transport::telnet::{
+        processor::TelnetEvent,
+        protocol::{NegotiationType, TelnetOption},
+    },
+};
+
+use super::{negotiator::OptionsNegotiatorBuilder, DynWriteStream, TelnetOptionHandler};
+
+const MSDP_VAR: u8 = 1;
+const MSDP_VAL: u8 = 2;
+const MSDP_TABLE_OPEN: u8 = 3;
+const MSDP_TABLE_CLOSE: u8 = 4;
+const MSDP_ARRAY_OPEN: u8 = 5;
+const MSDP_ARRAY_CLOSE: u8 = 6;
+
+struct MsdpVar(String, MsdpVal);
+
+impl Writable for MsdpVar {
+    fn write<S: io::Write>(self, stream: &mut S) -> io::Result<()> {
+        stream.write_all(&[MSDP_VAR])?;
+        stream.write_all(&self.0.as_bytes())?;
+        self.1.write(stream)
+    }
+}
+
+pub enum MsdpVal {
+    String(String),
+    Array(Vec<MsdpVal>),
+    Table(HashMap<String, MsdpVal>),
+}
+
+impl Writable for MsdpVal {
+    fn write<S: io::Write>(self, stream: &mut S) -> io::Result<()> {
+        stream.write_all(&[MSDP_VAL])?;
+        match self {
+            MsdpVal::String(s) => stream.write_all(&s.as_bytes()),
+            MsdpVal::Array(items) => {
+                stream.write_all(&[MSDP_ARRAY_OPEN])?;
+                for item in items {
+                    item.write(stream)?;
+                }
+                stream.write_all(&[MSDP_ARRAY_CLOSE])
+            }
+            MsdpVal::Table(items) => {
+                stream.write_all(&[MSDP_TABLE_OPEN])?;
+                for (key, val) in items {
+                    MsdpVar(key, val).write(stream)?;
+                }
+                stream.write_all(&[MSDP_TABLE_CLOSE])
+            }
+        }
+    }
+}
+
+pub enum MsdpEvent {
+    Reset,
+    UpdateVar(String, MsdpVal),
+}
+
+pub struct MsdpOptionHandler {}
+
+impl MsdpOptionHandler {
+    pub fn new() -> (Self, Option<usize>) {
+        (MsdpOptionHandler {}, None)
+    }
+}
+
+impl MsdpOptionHandler {
+    fn reset(&self) {}
+}
+
+#[async_trait]
+impl TelnetOptionHandler for MsdpOptionHandler {
+    fn option(&self) -> TelnetOption {
+        TelnetOption::MSDP
+    }
+
+    fn register(&self, negotiator: OptionsNegotiatorBuilder) -> OptionsNegotiatorBuilder {
+        negotiator.accept_will(TelnetOption::MSDP)
+    }
+
+    async fn negotiate(
+        &mut self,
+        negotiation: NegotiationType,
+        mut stream: DynWriteStream<'_>,
+    ) -> io::Result<()> {
+        match negotiation {
+            NegotiationType::Wont => {
+                self.reset();
+            }
+
+            NegotiationType::Will => {
+                let to_send = MsdpVar("LIST".to_string(), MsdpVal::String("COMMANDS".to_string()));
+                let command = TelnetEvent::Subnegotiate(TelnetOption::MSDP, to_send.into_bytes());
+
+                log::trace!(target: "telnet", ">> MSDP LIST COMMANDS");
+                stream.write_object(command).await?;
+            }
+
+            _ => {}
+        }
+        Ok(())
+    }
+
+    async fn subnegotiate(
+        &mut self,
+        data: bytes::Bytes,
+        _stream: DynWriteStream<'_>,
+    ) -> io::Result<()> {
+        log::trace!(target: "telnet", "<< MSDP (TODO) {:?}", data);
+        // TODO Parse MSDP data and stash somewhere
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds some initial support for parsing and sending MSDP data. A new `Event` RPC notification will be sent when an MSDP var is received. This notification should be generic enough to support more event types in the future:

```json
{
    "type": "Event",
    "connection_id": Id,
    "ns": String,
    "name": String,
    "payload": any,
}
```

The `ns` (namespace) key is used to disambiguate different event sources. For MSDP, the namespace is always `MSDP`; `name` holds the name of a var sent, and payload is the value.

Included also is a fixed and updated event listener registration in lua:

```lua
-- The second "name" item in the list is optional; if omitted, all events in the namespace
-- will be sent
s:on({"MSDP", "ROOM"}, function (room, _message)
  -- The first param to the handler is the `payload` of the message. If necessary, the
  -- full message object is also provided as the second param.
end)
```

- Begin work to support MSDP
- Simplify some common MSDP interactions
- Prepare support for reading MSDP values
- Support reading full MSDP_VARs; reuse this for tables
- Support reading repeated values/flat arrays (they're sometimes allowed)
- Emit MSDP VAR as simple events
- Stop parsing FlatArray
- Refactor MSDP to be relayed via a generic event interface
- Fix `KodachiState:on` not actually working properly
- Add `s:on({ NS, NAME }, handler)` syntax for observing Event... events
