### PR TITLE
Notify about prompt changes via RPC

### DIFF
--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -43,6 +43,11 @@ pub struct TextProcessor {
     pending_line: AnsiMut,
 }
 
+pub enum SystemMessage {
+    ConnectionStatus(String),
+    LocalSend(String),
+}
+
 pub trait ProcessorOutputReceiver {
     fn begin_chunk(&mut self) -> io::Result<()> {
         Ok(())
@@ -51,8 +56,6 @@ pub trait ProcessorOutputReceiver {
         Ok(())
     }
 
-    fn reset_colors(&mut self) -> io::Result<()>;
-
     fn new_line(&mut self) -> io::Result<()>;
     fn finish_line(&mut self) -> io::Result<()>;
 
@@ -60,6 +63,7 @@ pub trait ProcessorOutputReceiver {
     fn clear_partial_line(&mut self) -> io::Result<()>;
 
     fn text(&mut self, text: Ansi) -> io::Result<()>;
+    fn system(&mut self, text: SystemMessage) -> io::Result<()>;
     fn notification(&mut self, notification: DaemonNotification) -> io::Result<()>;
 
     #[cfg(dbg)]
@@ -237,7 +241,7 @@ mod tests {
             Ok(())
         }
 
-        fn reset_colors(&mut self) -> io::Result<()> {
+        fn system(&mut self, _message: SystemMessage) -> io::Result<()> {
             Ok(())
         }
 

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -13,7 +13,10 @@ use std::{
 use crate::{
     app::{
         clearable::Clearable,
-        processing::{ansi::Ansi, text::ProcessorOutputReceiver},
+        processing::{
+            ansi::Ansi,
+            text::{ProcessorOutputReceiver, SystemMessage},
+        },
         Id,
     },
     daemon::{
@@ -113,8 +116,11 @@ impl<W: Write> ProcessorOutputReceiver for AnsiTerminalWriteUI<W> {
         }
     }
 
-    fn reset_colors(&mut self) -> io::Result<()> {
-        ::crossterm::queue!(self.output, ResetColor)
+    fn system(&mut self, message: SystemMessage) -> io::Result<()> {
+        ::crossterm::queue!(self.output, ResetColor)?;
+        self.text(match message {
+            SystemMessage::ConnectionStatus(text) | SystemMessage::LocalSend(text) => text.into(),
+        })
     }
 
     fn new_line(&mut self) -> io::Result<()> {

--- a/src/cli/ui/prompts.rs
+++ b/src/cli/ui/prompts.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use crate::app::{clearable::Clearable, processing::ansi::Ansi, Id};
 
@@ -58,8 +58,8 @@ impl Clearable for PromptGroups {
 }
 
 impl PromptGroups {
-    pub fn get_mut(&mut self, group_id: Id) -> Option<&mut PromptsState> {
-        self.groups.get_mut(&group_id)
+    pub fn entry(&mut self, group_id: Id) -> Entry<Id, PromptsState> {
+        self.groups.entry(group_id)
     }
 
     pub fn insert(&mut self, group_id: Id, group: PromptsState) {

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -1,7 +1,10 @@
 use crate::{
     app::{
         matchers::{Matcher, MatcherSpec},
-        processing::text::{MatcherId, MatcherMode},
+        processing::{
+            ansi::Ansi,
+            text::{MatcherId, MatcherMode},
+        },
         Id, LockableState,
     },
     daemon::{channel::Channel, responses::DaemonResponse},
@@ -10,6 +13,7 @@ use crate::{
 use super::set_prompt_content;
 
 pub fn try_handle(
+    channel: &Channel,
     mut state: LockableState,
     connection_id: Id,
     matcher: MatcherSpec,
@@ -44,17 +48,19 @@ pub fn try_handle(
         index: prompt_index,
     };
 
+    let mut receiver = channel.for_connection(connection_id);
     processor_ref.lock().unwrap().register_matcher(
         id,
         compiled,
         MatcherMode::PartialLine,
         move |mut context| {
             set_prompt_content::try_handle(
+                Some(&mut receiver),
                 state.clone(),
                 connection_id,
                 group_id,
                 prompt_index,
-                context.take_full_match().ansi,
+                Ansi::from(context.take_full_match().ansi),
                 true,
             )?;
             Ok(())
@@ -72,11 +78,13 @@ pub async fn handle(
     group_id: Id,
     prompt_index: usize,
 ) {
-    channel.respond(try_handle(
+    let response = try_handle(
+        &channel,
         state,
         connection_id,
         matcher,
         group_id,
         prompt_index,
-    ));
+    );
+    channel.respond(response);
 }

--- a/src/daemon/handlers/register_prompt.rs
+++ b/src/daemon/handlers/register_prompt.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::set_prompt_content;
 
 pub fn try_handle(
-    channel: &Channel,
+    channel: Option<&Channel>,
     mut state: LockableState,
     connection_id: Id,
     matcher: MatcherSpec,
@@ -48,14 +48,14 @@ pub fn try_handle(
         index: prompt_index,
     };
 
-    let mut receiver = channel.for_connection(connection_id);
+    let mut receiver = channel.map(|channel| channel.for_connection(connection_id));
     processor_ref.lock().unwrap().register_matcher(
         id,
         compiled,
         MatcherMode::PartialLine,
         move |mut context| {
             set_prompt_content::try_handle(
-                Some(&mut receiver),
+                receiver.as_mut(),
                 state.clone(),
                 connection_id,
                 group_id,
@@ -79,7 +79,7 @@ pub async fn handle(
     prompt_index: usize,
 ) {
     let response = try_handle(
-        &channel,
+        Some(&channel),
         state,
         connection_id,
         matcher,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,7 +11,7 @@ pub mod protocol;
 pub mod requests;
 pub mod responses;
 
-use crate::app::LockableState;
+use crate::app::{processing::ansi::Ansi, LockableState};
 
 use self::{
     channel::{Channel, ChannelSource},
@@ -186,7 +186,7 @@ fn dispatch_request(state: LockableState, channel: Channel, payload: ClientReque
                 connection_id,
                 group_id,
                 prompt_index,
-                content,
+                Ansi::from(content),
                 set_group_active.unwrap_or(true),
             ));
         }

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -49,5 +49,13 @@ pub enum DaemonNotification {
         handler_id: Id,
         context: MatchContext,
     },
+    PromptUpdated {
+        group_id: Id,
+        index: usize,
+        content: MatchedText,
+    },
+    ActivePromptGroupChanged {
+        group_id: Id,
+    },
     Event(EventData),
 }

--- a/src/testbed.rs
+++ b/src/testbed.rs
@@ -1,5 +1,5 @@
 use crate::app::matchers::MatcherSpec;
-use crate::app::processing::text::ProcessorOutputReceiver;
+use crate::app::processing::text::{ProcessorOutputReceiver, SystemMessage};
 use crate::app::{Id, LockableState};
 use crate::cli::ui::AnsiTerminalWriteUI;
 use crate::daemon::handlers::register_prompt;
@@ -35,12 +35,34 @@ impl<R: ProcessorOutputReceiver> TestBed<R> {
         self.ui.end_chunk()
     }
 
+    fn send(&mut self, to_send: &str) -> io::Result<()> {
+        self.ui
+            .system(SystemMessage::LocalSend(to_send.to_string()))
+    }
+
     pub fn register_prompt(&mut self, group_id: Id, prompt_index: usize, prompt: &str) {
         let matcher = MatcherSpec::Regex {
             options: Default::default(),
             source: prompt.to_string(),
         };
-        register_prompt::try_handle(self.state.clone(), self.id, matcher, group_id, prompt_index);
+
+        // Basically, ignore sent messages:
+        let (response_sender, _) = tokio::sync::broadcast::channel(999);
+        let channels = ChannelSource::new(
+            Box::new(stderr()),
+            RequestIdGenerator::default(),
+            response_sender,
+        );
+        let channel = channels.create_with_request_id(self.id);
+
+        register_prompt::try_handle(
+            &channel,
+            self.state.clone(),
+            self.id,
+            matcher,
+            group_id,
+            prompt_index,
+        );
     }
 }
 
@@ -87,7 +109,7 @@ pub fn run() -> io::Result<()> {
     testbed.receive("Prompt fde")?;
 
     // Send some text:
-    testbed.receive("\r\n(look)\r\n")?;
+    testbed.send("(look)")?;
 
     testbed.receive("look1\r\n")?;
     testbed.receive("look2\r\n")?;

--- a/src/testbed.rs
+++ b/src/testbed.rs
@@ -46,17 +46,8 @@ impl<R: ProcessorOutputReceiver> TestBed<R> {
             source: prompt.to_string(),
         };
 
-        // Basically, ignore sent messages:
-        let (response_sender, _) = tokio::sync::broadcast::channel(999);
-        let channels = ChannelSource::new(
-            Box::new(stderr()),
-            RequestIdGenerator::default(),
-            response_sender,
-        );
-        let channel = channels.create_with_request_id(self.id);
-
         register_prompt::try_handle(
-            &channel,
+            None,
             self.state.clone(),
             self.id,
             matcher,


### PR DESCRIPTION
Useful if the client wants to render prompts itself. We will probably
eventually need some switches to disable local rendering in that case,
but most likely we won't be doing local rendering for that *anyway*.
