### PR TITLE
Add support for `--ui external`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -29,6 +29,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,7 +85,7 @@ checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -82,33 +131,49 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.79",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "core-foundation"
@@ -168,7 +233,7 @@ checksum = "6bc6b43b1626e75c776f282bcf592b58c6fdd9da069ecf733111a061f6a549a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -244,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -269,20 +334,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -420,9 +481,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -455,15 +519,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -512,7 +567,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -528,49 +583,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -713,7 +750,7 @@ checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -810,6 +847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,21 +870,6 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -879,7 +912,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -926,6 +959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,9 +972,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -966,15 +1005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,13 +1029,38 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1013,6 +1068,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1027,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1104,18 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1051,6 +1130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,10 +1148,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1079,3 +1176,9 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,15 @@ authors = ["Daniel Leong <me@dhleong.net>"]
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.23.0", features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.23.0", features = [
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tokio-native-tls = "0.3.0"
 async-trait = "0.1.59"
 flate2 = "1.0.25"
@@ -15,7 +23,7 @@ bytes = "1.1.0"
 native-tls = "0.2.8"
 url = "2.2.2"
 
-clap = { version = "3.1.7", features = ["derive"] }
+clap = { version = "=4.4.18", features = ["derive"] }
 crossterm = "0.23.2"
 supports-unicode = "1.0.2"
 supports-color = "1.3.1"

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -52,7 +52,6 @@ pub struct TextProcessor {
 
 pub enum SystemMessage {
     ConnectionStatus(String),
-    LocalSend(String),
 }
 
 pub trait ProcessorOutputReceiver {

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
 
 use bytes::Buf;
 
@@ -8,7 +11,11 @@ use crate::{
         matchers::{MatchResult, MatchedResult, Matcher},
         Id,
     },
-    daemon::notifications::{DaemonNotification, MatchContext},
+    cli::ui::UiState,
+    daemon::{
+        channel::RespondedChannel,
+        notifications::{DaemonNotification, MatchContext},
+    },
 };
 
 use super::ansi::{Ansi, AnsiMut};
@@ -81,6 +88,17 @@ pub enum MatcherMode {
 enum PerformMatchResult<'a> {
     Matched(&'a mut RegisteredMatcher, MatchedResult),
     Ignored(Ansi),
+}
+
+pub trait ProcessorOutputReceiverFactory: Clone + Send {
+    type Implementation: ProcessorOutputReceiver + Send;
+
+    fn create(
+        &self,
+        state: Arc<Mutex<UiState>>,
+        connection_id: Id,
+        notifier: RespondedChannel,
+    ) -> Self::Implementation;
 }
 
 impl TextProcessor {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 pub mod stdio;
 pub mod ui;
@@ -8,6 +8,16 @@ pub mod ui;
 pub struct Cli {
     #[clap(subcommand)]
     pub command: Commands,
+
+    #[arg(long, value_enum, global = true, default_value = "stdout")]
+    pub ui: UiType,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum UiType {
+    Stdout,
+
+    External,
 }
 
 #[derive(Subcommand, PartialEq)]

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1,3 +1,4 @@
+pub mod external;
 pub mod prompts;
 
 use crossterm::{

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -122,7 +122,7 @@ impl<W: Write> ProcessorOutputReceiver for AnsiTerminalWriteUI<W> {
         self.clear_partial_line()?;
         self.new_line()?;
         self.text(match message {
-            SystemMessage::ConnectionStatus(text) | SystemMessage::LocalSend(text) => text.into(),
+            SystemMessage::ConnectionStatus(text) => text.into(),
         })?;
         self.finish_line()
     }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -15,7 +15,7 @@ use crate::{
         clearable::Clearable,
         processing::{
             ansi::Ansi,
-            text::{ProcessorOutputReceiver, SystemMessage},
+            text::{ProcessorOutputReceiver, ProcessorOutputReceiverFactory, SystemMessage},
         },
         Id,
     },
@@ -185,5 +185,21 @@ impl<W: Write> ProcessorOutputReceiver for AnsiTerminalWriteUI<W> {
             notification,
         });
         Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct StdoutAnsiTerminalWriteUIFactory;
+
+impl ProcessorOutputReceiverFactory for StdoutAnsiTerminalWriteUIFactory {
+    type Implementation = AnsiTerminalWriteUI<io::Stdout>;
+
+    fn create(
+        &self,
+        state: Arc<Mutex<UiState>>,
+        connection_id: Id,
+        notifier: RespondedChannel,
+    ) -> Self::Implementation {
+        AnsiTerminalWriteUI::create(state, connection_id, notifier, io::stdout())
     }
 }

--- a/src/cli/ui/external.rs
+++ b/src/cli/ui/external.rs
@@ -1,0 +1,81 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    app::{
+        processing::text::{ProcessorOutputReceiver, ProcessorOutputReceiverFactory},
+        Id,
+    },
+    daemon::channel::RespondedChannel,
+};
+
+use super::UiState;
+
+pub struct ExternalUI {
+    state: Arc<Mutex<UiState>>,
+    connection_id: Id,
+    notifier: RespondedChannel,
+}
+
+impl ExternalUI {
+    pub fn create(
+        state: Arc<Mutex<UiState>>,
+        connection_id: Id,
+        notifier: RespondedChannel,
+    ) -> Self {
+        Self {
+            state,
+            connection_id,
+            notifier,
+        }
+    }
+}
+
+impl ProcessorOutputReceiver for ExternalUI {
+    fn new_line(&mut self) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn finish_line(&mut self) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn clear_partial_line(&mut self) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn text(&mut self, text: crate::app::processing::ansi::Ansi) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn system(&mut self, text: crate::app::processing::text::SystemMessage) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn notification(
+        &mut self,
+        notification: crate::daemon::notifications::DaemonNotification,
+    ) -> std::io::Result<()> {
+        self.notifier
+            .notify(crate::daemon::protocol::Notification::ForConnection {
+                connection_id: self.connection_id,
+                notification,
+            });
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ExternalUIFactory;
+
+impl ProcessorOutputReceiverFactory for ExternalUIFactory {
+    type Implementation = ExternalUI;
+
+    fn create(
+        &self,
+        state: Arc<Mutex<UiState>>,
+        connection_id: Id,
+        notifier: RespondedChannel,
+    ) -> Self::Implementation {
+        ExternalUI::create(state, connection_id, notifier)
+    }
+}

--- a/src/daemon/notifications.rs
+++ b/src/daemon/notifications.rs
@@ -1,3 +1,5 @@
+pub mod external_ui;
+
 use std::{collections::HashMap, ops::Range};
 
 use serde::Serialize;
@@ -6,6 +8,8 @@ use crate::{
     app::{processing::ansi::Ansi, Id},
     transport::EventData,
 };
+
+use self::external_ui::ExternalUINotification;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct MatchedText {
@@ -56,6 +60,9 @@ pub enum DaemonNotification {
     },
     ActivePromptGroupChanged {
         group_id: Id,
+    },
+    ExternalUI {
+        data: ExternalUINotification,
     },
     Event(EventData),
 }

--- a/src/daemon/notifications/external_ui.rs
+++ b/src/daemon/notifications/external_ui.rs
@@ -1,0 +1,11 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+pub enum ExternalUINotification {
+    NewLine,
+    FinishLine,
+    ClearPartialLine,
+    Text { ansi: String },
+    ConnectionStatus { text: String },
+}

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -75,14 +75,52 @@ impl RequestIdGenerator {
 mod tests {
     use super::*;
 
-    #[test]
-    fn serialization_test() {
-        let s = serde_json::to_string(&Notification::ForConnection {
-            connection_id: 42,
-            notification: DaemonNotification::Connected,
-        })
-        .unwrap();
-        assert_eq!(s, r#"{"connection_id":42,"type":"Connected"}"#);
+    #[cfg(test)]
+    mod serialization_tests {
+        use crate::daemon::notifications::external_ui::ExternalUINotification;
+
+        use super::*;
+
+        #[test]
+        fn connected_test() {
+            let s = serde_json::to_string(&Notification::ForConnection {
+                connection_id: 42,
+                notification: DaemonNotification::Connected,
+            })
+            .unwrap();
+            assert_eq!(s, r#"{"connection_id":42,"type":"Connected"}"#);
+        }
+
+        #[test]
+        fn external_ui_test() {
+            let s = serde_json::to_string(&Notification::ForConnection {
+                connection_id: 42,
+                notification: DaemonNotification::ExternalUI {
+                    data: ExternalUINotification::Text {
+                        ansi: "Welcome!".to_string(),
+                    },
+                },
+            })
+            .unwrap();
+            assert_eq!(
+                s,
+                r#"{"connection_id":42,"type":"ExternalUI","data":{"type":"Text","ansi":"Welcome!"}}"#
+            );
+
+            let s = serde_json::to_string(&Notification::ForConnection {
+                connection_id: 42,
+                notification: DaemonNotification::ExternalUI {
+                    data: ExternalUINotification::ConnectionStatus {
+                        text: "Connected!".to_string(),
+                    },
+                },
+            })
+            .unwrap();
+            assert_eq!(
+                s,
+                r#"{"connection_id":42,"type":"ExternalUI","data":{"type":"ConnectionStatus","text":"Connected!"}}"#
+            );
+        }
     }
 
     #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use clap::StructOpt;
+use cli::ui::StdoutAnsiTerminalWriteUIFactory;
 use cli::{Cli, Commands};
 
 mod app;
@@ -23,7 +24,8 @@ async fn run(cli: Cli) -> io::Result<()> {
         Commands::Stdio => {
             let input = StdinReader::stdin();
             let response = io::stderr();
-            daemon::daemon(input, response).await
+            let ui = StdoutAnsiTerminalWriteUIFactory;
+            daemon::daemon(ui, input, response).await
         }
 
         Commands::Unix { path } => {
@@ -33,7 +35,8 @@ async fn run(cli: Cli) -> io::Result<()> {
             };
             let input = BufReader::new(socket.try_clone().unwrap());
             let response = socket;
-            daemon::daemon(input, response).await
+            let ui = StdoutAnsiTerminalWriteUIFactory;
+            daemon::daemon(ui, input, response).await
         }
 
         Commands::Testbed => panic!(),


### PR DESCRIPTION
This lets us embed kodachi as a headless daemon inside an external UI that wants to handle windowing and color rendering itself. It might be nice to parse the ANSI data for the client, but we do not currently---we could potentially introduce it as a `parsed` field on the `MatchedText` type to not break backwards compatibility.
