### PR TITLE
Fix and simplify output processing + handling

### DIFF
--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -80,6 +80,12 @@ pub struct Ansi {
     stripped: Option<AnsiStripped>,
 }
 
+impl Default for Ansi {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl Debug for Ansi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.bytes.fmt(f)

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -79,7 +79,7 @@ impl SendTextProcessor {
                 MatchResult::Ignored(ignored) => to_match = ignored,
                 MatchResult::Matched(MatchedResult {
                     context,
-                    mut remaining,
+                    remaining: Some(mut remaining),
                     ..
                 }) => {
                     // NOTE: Since the matcher *shouldn't* consume, remaining *should*
@@ -94,6 +94,11 @@ impl SendTextProcessor {
                         return Ok(ProcessResult::Stop);
                     }
                 }
+
+                // If the matcher *did* consume for some reason... nothing else to do
+                MatchResult::Matched(MatchedResult {
+                    remaining: None, ..
+                }) => return Ok(ProcessResult::Stop),
             }
         }
 

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -145,7 +145,6 @@ impl TextProcessor {
         }
 
         receiver.clear_partial_line()?;
-        // receiver.new_line()?;
 
         let (match_mode, to_match) = if has_full_line {
             let mut full_line = self.pending_line.take();
@@ -180,10 +179,6 @@ impl TextProcessor {
         }
 
         receiver.finish_line()?;
-
-        // if has_full_line {
-        //     receiver.new_line()?;
-        // }
 
         Ok(())
     }

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -145,7 +145,7 @@ impl TextProcessor {
         }
 
         receiver.clear_partial_line()?;
-        receiver.new_line()?;
+        // receiver.new_line()?;
 
         let (match_mode, to_match) = if has_full_line {
             let mut full_line = self.pending_line.take();
@@ -168,11 +168,22 @@ impl TextProcessor {
                 remaining
             }
 
-            PerformMatchResult::Ignored(text) => text,
+            PerformMatchResult::Ignored(text) => Some(text),
         };
 
-        receiver.text(to_print)?;
+        if let Some(to_print) = to_print {
+            receiver.text(to_print)?;
+
+            if has_full_line {
+                receiver.new_line()?;
+            }
+        }
+
         receiver.finish_line()?;
+
+        // if has_full_line {
+        //     receiver.new_line()?;
+        // }
 
         Ok(())
     }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -2,7 +2,7 @@ pub mod external;
 pub mod prompts;
 
 use crossterm::{
-    cursor::{MoveToColumn, MoveToPreviousLine},
+    cursor::MoveToPreviousLine,
     style::ResetColor,
     terminal::{Clear, ClearType},
 };
@@ -83,23 +83,9 @@ impl<W: Write> ProcessorOutputReceiver for AnsiTerminalWriteUI<W> {
     fn clear_partial_line(&mut self) -> io::Result<()> {
         let columns = self.internal.printed_columns;
         self.internal.printed_columns = 0;
-        // if columns == 0 {
-        //     return Ok(());
-        // }
 
         let (width, _) = ::crossterm::terminal::size()?;
         let printed_lines = if columns == 0 { 0 } else { columns / width + 1 };
-
-        // // Also clear any "clean" prompt lines when dirty, since we're preparing
-        // // to print a line, which will result in prompts being fully restored
-        // let state = self.state.lock().unwrap();
-        // let total_prompt_lines = state.prompts.len();
-        // let clean_prompt_lines = state.prompts.get_clean_lines();
-        // let extra_lines_to_clean = if clean_prompt_lines < total_prompt_lines {
-        //     clean_prompt_lines as u16
-        // } else {
-        //     0
-        // };
 
         let extra_lines_to_clean = self.internal.rendered_prompt_lines;
         self.internal.rendered_prompt_lines = 0;
@@ -108,12 +94,6 @@ impl<W: Write> ProcessorOutputReceiver for AnsiTerminalWriteUI<W> {
         if lines == 0 {
             // nop? Already on a cleared line
             Ok(())
-            // ::crossterm::queue!(
-            //     self.output,
-            //     MoveToColumn(1),
-            //     Clear(ClearType::UntilNewLine),
-            //     Clear(ClearType::FromCursorDown)
-            // )
         } else {
             ::crossterm::queue!(
                 self.output,

--- a/src/cli/ui/prompts.rs
+++ b/src/cli/ui/prompts.rs
@@ -5,13 +5,11 @@ use crate::app::{clearable::Clearable, processing::ansi::Ansi, Id};
 #[derive(Default)]
 pub struct PromptsState {
     values: Vec<Option<Ansi>>,
-    set_values: usize,
 }
 
 impl Clearable for PromptsState {
     fn clear(&mut self) {
         self.values.clear();
-        self.set_values = 0;
     }
 }
 
@@ -28,9 +26,9 @@ impl PromptsState {
         self.values.len()
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn get(&self, index: usize) -> Option<&Ansi> {
-        self.values.get(index).map_or(None, |v| v.as_ref())
+        self.values.get(index).and_then(|v| v.as_ref())
     }
 
     pub fn set_index(&mut self, index: usize, content: Ansi) {
@@ -38,11 +36,6 @@ impl PromptsState {
             self.values.push(None);
         }
         self.values[index] = Some(content.trim_end_matches("\r\n").into());
-        self.set_values = index + 1;
-    }
-
-    pub fn get_clean_lines(&self) -> usize {
-        self.set_values
     }
 }
 

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -46,7 +46,7 @@ pub async fn process_connection<T: Transport, R: ProcessorOutputReceiver>(
             outgoing = connection.outbox.recv() => {
                 match outgoing {
                     Some(Outgoing::Text(text)) => {
-                        transport.write(&text.as_bytes()).await?;
+                        transport.write(text.as_bytes()).await?;
                         transport.write(b"\r\n").await?;
 
                         // Also print locally
@@ -110,7 +110,7 @@ pub async fn handle<TUI: ProcessorOutputReceiverFactory>(
                     format!("Disconnected: {}", error)
                 };
                 receiver.begin_chunk()?;
-                receiver.system(SystemMessage::ConnectionStatus(format!("\n{}\n", message)))?;
+                receiver.system(SystemMessage::ConnectionStatus(message))?;
                 receiver.end_chunk()?;
             }
             _ => {

--- a/src/testbed.rs
+++ b/src/testbed.rs
@@ -69,19 +69,51 @@ pub fn run() -> io::Result<()> {
 
     let mut state = LockableState::default();
     let connection = state.lock().unwrap().connections.create();
-    let ui = AnsiTerminalWriteUI::create(connection.state.ui_state.clone(), 0, notifier, out);
-    let mut testbed = TestBed {
+    let mut ui = AnsiTerminalWriteUI::create(connection.state.ui_state.clone(), 0, notifier, out);
+
+    {
+        let mut state = connection.state.ui_state.lock().unwrap();
+        state.prompts.set_index(0, "Prompt ABC".into());
+    }
+
+    // ui.begin_chunk()?;
+    // ui.clear_partial_line()?;
+    // ui.text("Test".into())?;
+    // ui.finish_line()?;
+    // ui.end_chunk()?;
+
+    // ui.begin_chunk()?;
+    // ui.clear_partial_line()?;
+    // ui.text("Test two\r\n".into())?;
+    // ui.new_line()?;
+    // ui.finish_line()?;
+    // ui.end_chunk()?;
+
+    // ui.begin_chunk()?;
+    // ui.clear_partial_line()?;
+    // ui.text("Test three\r\n".into())?;
+    // ui.new_line()?;
+    // ui.finish_line()?;
+    // ui.end_chunk()?;
+
+    // Ok(())
+
+    let testbed = TestBed {
         state,
         id: connection.id,
         ui,
     };
+    run_test_bed(testbed)
+}
 
+fn run_test_bed<V: ProcessorOutputReceiver>(mut testbed: TestBed<V>) -> io::Result<()> {
     testbed.register_prompt(0, 0, "^Prompt ([a-c]+).*$");
     testbed.register_prompt(0, 1, "^Prompt ([d-f]+).*$");
 
     testbed.receive("Output line 1\r\nPrompt abc\r\nPrompt def")?;
     testbed.receive("\r\n")?;
     testbed.receive("Lorem ipsum dolor sit amit bacon")?;
+
     testbed.receive("~Lorem ipsum dolor sit amit bacon Lorem ipsum dolor sit amit bacon\r\n")?;
 
     testbed.receive("Prompt cba")?;


### PR DESCRIPTION
I'm not entirely sure what was going on with the old version. It was very complicated, hard to reason about, and incorrect. The ANSI UI might cause duplicate lines when appending text to a partial line, and the ExternalUI integration resulted in incorrect blank spaces.

The new flow can be described as follows:

1. Start with `begin_chunk`. This describes a batched group of commands
2. When appending text, we always start with `clear_partial_line`. This should remove the current line of text, as well as anything like prompts below it.
3. Next, print the full state of the current line via `text`. If we previously had a partial line and have received more text on that line, we print out *the entire line*. This may seem slightly inefficient, but it allows clean handling of prompts in the ANSI UI. `ExternalUI` could possibly optimize this use case by detecting an append to a partial line, but simply replacing a line shouldn't be terribly painful, and is easier.
4. If we just printed a "full" line (IE: ending with "\r\n") that will not be processed any further, we'll send `new_line`. This may be mostly useful for `ExternalUI` clients
5. Finally we `finish_line` as a signal that prompts may be redrawn, and `end_chunk` to complete the batch.
