### PR TITLE
Add support for EOR to auto-define prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ it can be reused with whatever editors support embedding a terminal window.
 - [x] Aliases
 - [x] Intelligent auto-completion
 - [x] Input history management
-- [x] Common MUD protocols: [MTTS][mtts], [MCCP2][mccp2], [MSDP][msdp], [NAWS][naws]
+- [x] Common MUD protocols: [MTTS][mtts], [MCCP2][mccp2], [MSDP][msdp], [NAWS][naws], [EOR][eor]
 - [x] Secure connections over TLS
 
 
@@ -105,6 +105,7 @@ require 'null-ls'.setup {
 [rust]: https://www.rust-lang.org
 [plug]: https://github.com/junegunn/vim-plug
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
+[eor]: https://tintin.mudhalla.net/protocols/eor/
 [mtts]: https://mudhalla.net/tintin/protocols/mtts/
 [mccp2]: https://tintin.mudhalla.net/protocols/mccp/
 [msdp]: https://tintin.mudhalla.net/protocols/msdp/

--- a/lua/kodachi/state.lua
+++ b/lua/kodachi/state.lua
@@ -70,7 +70,7 @@ function KodachiState:cleanup()
 
   if cleared_any and self.socket and self.connection_id then
     self.socket:notify {
-      type = "Clear",
+      type = 'Clear',
       connection_id = self.connection_id,
     }
   end
@@ -92,6 +92,18 @@ function KodachiState:command(name, handler, opts)
 
   -- TODO also create in the composer
   vim.api.nvim_buf_create_user_command(self.bufnr, name, callback, full_opts)
+end
+
+--- @alias KodachiConnectionConfig {auto_prompts: boolean|nil}
+
+--- Update the connection configuration
+--- @param config KodachiConnectionConfig
+function KodachiState:config(config)
+  return with_socket(self, function(socket)
+    socket:request(vim.tbl_extend('force', config, {
+      type = 'ConfigureConnection',
+    }))
+  end)
 end
 
 ---Create a keymapping in normal mode for the buffer associated with this state. These mappings
@@ -151,9 +163,9 @@ end
 function KodachiState:alias(matcher, handler)
   matcher = matchers.inflate(matcher)
   return with_socket(self, function(socket)
-    if type(handler) == "string" then
+    if type(handler) == 'string' then
       socket:request {
-        type = "RegisterAlias",
+        type = 'RegisterAlias',
         connection_id = self.connection_id,
         matcher = matcher,
         replacement_pattern = handler,
@@ -162,7 +174,7 @@ function KodachiState:alias(matcher, handler)
       local aliases = self:_alias_handlers(socket)
       local id = aliases:insert(handler)
       socket:request {
-        type = "RegisterAlias",
+        type = 'RegisterAlias',
         connection_id = self.connection_id,
         matcher = matcher,
         handler_id = id,
@@ -197,7 +209,7 @@ function KodachiState:trigger(matcher, handler)
     local triggers = self:_trigger_handlers(socket)
     local id = triggers:insert(handler)
     socket:request {
-      type = "RegisterTrigger",
+      type = 'RegisterTrigger',
       connection_id = self.connection_id,
       matcher = matcher,
       handler_id = id,
@@ -211,7 +223,7 @@ function KodachiState:send(text)
   return with_socket(self, function(socket)
     socket:request(
       {
-        type = "Send",
+        type = 'Send',
         connection_id = self.connection_id,
         text = text,
       },
@@ -283,7 +295,7 @@ function KodachiState:_trigger_handlers(socket)
 end
 
 function KodachiState:_state_method_call(method_call)
-  return "require'kodachi.states'[" .. self.bufnr .. "]:" .. method_call
+  return "require'kodachi.states'[" .. self.bufnr .. ']:' .. method_call
 end
 
 function KodachiState:_state_method_cmd(method_call)

--- a/src/app/connections.rs
+++ b/src/app/connections.rs
@@ -29,6 +29,12 @@ pub struct ConnectionState {
     pub ui_state: Arc<Mutex<UiState>>,
 }
 
+impl ConnectionState {
+    pub fn is_auto_prompt_enabled(&self) -> bool {
+        self.ui_state.lock().unwrap().is_auto_prompt_enabled
+    }
+}
+
 #[derive(Clone)]
 pub struct Connection {
     pub outbox: mpsc::Sender<Outgoing>,

--- a/src/app/processors.rs
+++ b/src/app/processors.rs
@@ -1,6 +1,12 @@
+use crate::daemon::{channel::RespondedConnectionChannel, handlers::set_prompt_content};
+
 use super::{connections::ConnectionReceiver, LockableState};
 
-pub fn register_processors(state: LockableState, connection: &mut ConnectionReceiver) {
+pub fn register_processors(
+    state: LockableState,
+    connection: &mut ConnectionReceiver,
+    receiver: RespondedConnectionChannel,
+) {
     let connection_id = connection.id;
     let mut processor = connection.state.processor.lock().unwrap();
 
@@ -19,6 +25,20 @@ pub fn register_processors(state: LockableState, connection: &mut ConnectionRece
                 .unwrap()
                 .process_incoming(line);
         }
+        Ok(())
+    });
+
+    processor.register_auto_prompt_processor(move |line| {
+        let mut my_receiver = receiver.clone();
+        set_prompt_content::try_handle(
+            Some(&mut my_receiver),
+            state.clone(),
+            connection_id,
+            0,
+            0,
+            line.to_owned(),
+            true,
+        )?;
         Ok(())
     });
 }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -35,6 +35,7 @@ pub struct UiState {
     pub prompts: PromptsState,
     pub active_prompt_group: Id,
     pub inactive_prompt_groups: PromptGroups,
+    pub is_auto_prompt_enabled: bool,
 }
 
 impl Clearable for UiState {

--- a/src/daemon/commands.rs
+++ b/src/daemon/commands.rs
@@ -10,6 +10,9 @@ use super::protocol::cursors::HistoryCursor;
 #[derive(Debug, Deserialize)]
 pub struct Connect {
     pub uri: String,
+
+    #[serde(flatten)]
+    pub config: Option<ConnectionConfig>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -17,6 +20,11 @@ pub struct Connect {
 pub enum AliasReplacement {
     Handler { handler_id: Id },
     Simple { replacement_pattern: FormatterSpec },
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+pub struct ConnectionConfig {
+    pub auto_prompts: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -29,6 +37,13 @@ pub enum ClientRequest {
     Send {
         connection_id: Id,
         text: String,
+    },
+
+    ConfigureConnection {
+        connection_id: Id,
+
+        #[serde(flatten)]
+        config: ConnectionConfig,
     },
 
     GetHistory {

--- a/src/daemon/handlers/configure_connection.rs
+++ b/src/daemon/handlers/configure_connection.rs
@@ -1,0 +1,33 @@
+use std::io;
+
+use crate::{
+    app::{connections::ConnectionState, Id, LockableState},
+    daemon::{channel::Channel, commands::ConnectionConfig, responses::DaemonResponse},
+};
+
+pub fn apply_config(connection: &mut ConnectionState, config: &ConnectionConfig) {
+    let mut ui_state = connection.ui_state.lock().unwrap();
+    if let Some(enable_auto_prompts) = config.auto_prompts {
+        ui_state.is_auto_prompt_enabled = enable_auto_prompts;
+    }
+}
+
+pub async fn handle(
+    channel: Channel,
+    mut state: LockableState,
+    connection_id: Id,
+    config: ConnectionConfig,
+) -> io::Result<()> {
+    let mut state = state.lock().unwrap();
+    let Some(mut connection) = state.connections.get_state(connection_id) else {
+        channel.respond(DaemonResponse::ErrorResult {
+            error: format!("Invalid connection ID {connection_id}"),
+        });
+        return Ok(());
+    };
+
+    apply_config(&mut connection, &config);
+
+    channel.respond(DaemonResponse::OkResult);
+    Ok(())
+}

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -32,6 +32,8 @@ use crate::{
     transport::{BoxedTransport, Transport, TransportEvent, TransportNotification},
 };
 
+use super::configure_connection::apply_config;
+
 pub async fn process_connection<T: Transport, R: ProcessorOutputReceiver>(
     mut transport: T,
     mut connection: ConnectionReceiver,
@@ -146,6 +148,10 @@ pub async fn handle<TUI: ProcessorOutputReceiverFactory>(
     let mut connection = state.lock().unwrap().connections.create();
     let uri = Uri::from_string(&data.uri)?;
     let connection_id = connection.id;
+
+    if let Some(config) = data.config {
+        apply_config(&mut connection.state, &config);
+    }
 
     let notifier = channel.respond(DaemonResponse::Connecting { connection_id });
     let receiver_state = connection.state.ui_state.clone();

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -94,6 +94,15 @@ pub async fn process_connection<T: Transport, R: ProcessorOutputReceiver>(
                     receiver.notification(DaemonNotification::Event(data))?;
                 },
 
+                TransportEvent::EndOfPrompt => {
+                    if connection.state.is_auto_prompt_enabled() {
+                        let processor = &connection
+                            .state
+                            .processor;
+                        handle_end_of_prompt(receiver, processor)?;
+                    }
+                },
+
                 TransportEvent::Nop => {},
             },
 
@@ -140,7 +149,8 @@ pub async fn handle<TUI: ProcessorOutputReceiverFactory>(
 
     let notifier = channel.respond(DaemonResponse::Connecting { connection_id });
     let receiver_state = connection.state.ui_state.clone();
-    let mut receiver = ui.create(receiver_state, connection_id, notifier);
+    let mut receiver = ui.create(receiver_state.clone(), connection_id, notifier.clone());
+    let processor_receiver = notifier.for_connection(connection_id);
 
     let transport = match BoxedTransport::connect_uri(uri, 4096).await {
         Ok(transport) => transport,
@@ -156,7 +166,7 @@ pub async fn handle<TUI: ProcessorOutputReceiverFactory>(
         }
     };
 
-    register_processors(state.clone(), &mut connection);
+    register_processors(state.clone(), &mut connection, processor_receiver);
 
     receiver.notification(DaemonNotification::Connected)?;
 
@@ -212,4 +222,15 @@ pub fn handle_sent_text<R: ProcessorOutputReceiver>(
     receiver.end_chunk()?;
 
     Ok(())
+}
+
+pub fn handle_end_of_prompt<R: ProcessorOutputReceiver>(
+    receiver: &mut R,
+    processor: &Mutex<TextProcessor>,
+) -> io::Result<()> {
+    receiver.begin_chunk()?;
+
+    processor.lock().unwrap().on_end_of_prompt(receiver)?;
+
+    receiver.end_chunk()
 }

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod clear;
 pub mod complete_composer;
+pub mod configure_connection;
 pub mod connect;
 pub mod disconnect;
 pub mod get_history;

--- a/src/daemon/handlers/register_trigger.rs
+++ b/src/daemon/handlers/register_trigger.rs
@@ -4,7 +4,11 @@ use crate::{
         processing::text::{MatcherId, MatcherMode},
         Id, LockableState,
     },
-    daemon::{channel::Channel, notifications::DaemonNotification, responses::DaemonResponse},
+    daemon::{
+        channel::{Channel, ConnectionNotifier},
+        notifications::DaemonNotification,
+        responses::DaemonResponse,
+    },
 };
 
 pub async fn handle(

--- a/src/daemon/handlers/set_active_prompt_group.rs
+++ b/src/daemon/handlers/set_active_prompt_group.rs
@@ -3,14 +3,14 @@ use std::io;
 use crate::{
     app::{Id, LockableState},
     daemon::{
-        channel::{Channel, ConnectionChannel},
+        channel::{Channel, ConnectionChannel, ConnectionNotifier},
         notifications::DaemonNotification,
         responses::DaemonResponse,
     },
 };
 
 pub async fn handle(channel: Channel, state: LockableState, connection_id: Id, group_id: Id) {
-    match try_handle(None, state, connection_id, group_id) {
+    match try_handle::<ConnectionChannel>(None, state, connection_id, group_id) {
         Ok(_) => channel.respond(DaemonResponse::OkResult),
         Err(e) => channel.respond(DaemonResponse::ErrorResult {
             error: e.to_string(),
@@ -18,8 +18,8 @@ pub async fn handle(channel: Channel, state: LockableState, connection_id: Id, g
     };
 }
 
-pub fn try_handle(
-    receiver: Option<&mut ConnectionChannel>,
+pub fn try_handle<N: ConnectionNotifier>(
+    receiver: Option<&mut N>,
     mut state: LockableState,
     connection_id: Id,
     group_id: Id,

--- a/src/daemon/handlers/set_prompt_content.rs
+++ b/src/daemon/handlers/set_prompt_content.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::{
     app::{processing::ansi::Ansi, Id, LockableState},
     daemon::{
-        channel::{Channel, ConnectionChannel},
+        channel::{Channel, ConnectionChannel, ConnectionNotifier},
         notifications::{DaemonNotification, MatchedText},
         responses::DaemonResponse,
     },
@@ -20,7 +20,7 @@ pub async fn handle(
     content: Ansi,
     set_group_active: bool,
 ) {
-    match try_handle(
+    match try_handle::<ConnectionChannel>(
         None,
         state,
         connection_id,
@@ -36,8 +36,8 @@ pub async fn handle(
     };
 }
 
-pub fn try_handle(
-    mut receiver: Option<&mut ConnectionChannel>,
+pub fn try_handle<N: ConnectionNotifier>(
+    mut receiver: Option<&mut N>,
     mut state: LockableState,
     connection_id: Id,
     group_id: Id,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -108,11 +108,25 @@ fn dispatch_request<TUI: ProcessorOutputReceiverFactory + 'static>(
         ClientRequest::Connect(data) => {
             launch(handlers::connect::handle(ui, channel, state, data));
         }
+
+        ClientRequest::ConfigureConnection {
+            connection_id,
+            config,
+        } => {
+            launch(handlers::configure_connection::handle(
+                channel,
+                state,
+                connection_id,
+                config,
+            ));
+        }
+
         ClientRequest::Disconnect {
             connection_id: connection,
         } => {
             tokio::spawn(handlers::disconnect::handle(channel, state, connection));
         }
+
         ClientRequest::Send {
             connection_id: connection,
             text,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -28,6 +28,7 @@ pub struct EventData {
 pub enum TransportEvent {
     Data(Bytes),
     Event(EventData),
+    EndOfPrompt,
     Nop,
 }
 

--- a/src/transport/telnet/mod.rs
+++ b/src/transport/telnet/mod.rs
@@ -3,6 +3,7 @@ use std::io;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use log::trace;
+use protocol::TelnetCommand;
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::TcpStream,
@@ -99,6 +100,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> TelnetTransport<S> {
                 }
 
                 Ok(Some(TransportEvent::Nop))
+            }
+            Some(TelnetEvent::Command(TelnetCommand::EOR)) => {
+                // The server has told us there's a prompt here
+                Ok(Some(TransportEvent::EndOfPrompt))
             }
             Some(_) => {
                 // TODO: Log unexpected event?

--- a/src/transport/telnet/options/mod.rs
+++ b/src/transport/telnet/options/mod.rs
@@ -89,7 +89,7 @@ impl Default for TelnetOptionsManager {
         // Build the negotiator, adding in extra options not managed by a Handler
         let negotiator = negotiator_builder
             .accept_will(TelnetOption::EOR)
-            // .accept_will(TelnetOption::MCCP2)
+            .accept_will(TelnetOption::MCCP2)
             .build();
 
         TelnetOptionsManager {

--- a/src/transport/telnet/options/mod.rs
+++ b/src/transport/telnet/options/mod.rs
@@ -87,7 +87,10 @@ impl Default for TelnetOptionsManager {
         }
 
         // Build the negotiator, adding in extra options not managed by a Handler
-        let negotiator = negotiator_builder.accept_will(TelnetOption::MCCP2).build();
+        let negotiator = negotiator_builder
+            .accept_will(TelnetOption::EOR)
+            // .accept_will(TelnetOption::MCCP2)
+            .build();
 
         TelnetOptionsManager {
             negotiator,

--- a/src/transport/telnet/protocol.rs
+++ b/src/transport/telnet/protocol.rs
@@ -71,6 +71,7 @@ macro_rules! declare_type {
 }
 
 declare_type!(TelnetCommand {
+    EOR => 239,
     GoAhead => 249,
 });
 
@@ -78,6 +79,7 @@ declare_type!(TelnetOption {
     Echo => 1,
     SuppressGoAhead => 3,
     TermType => 24,
+    EOR => 25,
     // Negotiate About Window Size
     Naws => 31,
     Charset => 42,


### PR DESCRIPTION
MUD Servers that support [EOR][eor] can tell clients when they have just sent a prompt; we can use that (if desired) to automatically extract the prompt. To opt in, this would look like:

```lua
local kodachi = require("kodachi")

kodachi.with_connection(uri, function (s)
  s:config { auto_prompts = true }
end)
```

[eor]: https://tintin.mudhalla.net/protocols/eor/
