### PR TITLE
Prevent unsafe utf8 conversion

### DIFF
--- a/src/app/matchers.rs
+++ b/src/app/matchers.rs
@@ -54,15 +54,13 @@ pub struct Matcher {
 }
 
 impl Matcher {
-    pub fn try_match(&self, mut subject: Ansi) -> MatchResult {
+    pub fn try_match(&self, subject: Ansi) -> MatchResult {
         let stripped: AnsiStripped = subject.trim_trailing_newlines().strip_ansi();
         if let Some(found) = self.pattern.captures(&stripped) {
             let context = self.extract_match_context(&stripped, found);
 
             let mut remaining = if self.options.consume {
-                let consumed_range = stripped.get_original_range(context.full_match_range.clone());
-                subject.slice(0..consumed_range.start)
-                    + subject.slice(consumed_range.end..subject.len())
+                subject.without_stripped_match_range(&stripped, context.full_match_range.clone())
             } else {
                 subject
             };
@@ -160,7 +158,7 @@ mod tests {
             assert_eq!(&context.indexed[&0].plain, "say 'anything'");
             assert_eq!(&context.indexed[&1].plain, "anything");
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -183,7 +181,7 @@ mod tests {
             assert_eq!(&context.indexed[&0].plain, "say 'anything'");
             assert_eq!(&context.indexed[&1].plain, "anything");
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -206,7 +204,7 @@ mod tests {
             assert_eq!(&context.indexed[&0].plain, "say 'anything'");
             assert_eq!(&context.named[&"message".to_string()].plain, "anything");
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -234,7 +232,7 @@ mod tests {
                 "\x1b[32manything\x1b[m"
             );
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -265,7 +263,7 @@ mod tests {
                 "\x1b[32manything\x1b[m"
             );
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -296,7 +294,7 @@ mod tests {
                 "\x1b[32manything\x1b[m"
             );
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -321,7 +319,7 @@ mod tests {
             assert_eq!(remaining, None);
             assert_eq!(&context.indexed[&0].plain, "For the honor of Grayskull!");
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 
@@ -338,7 +336,7 @@ mod tests {
         {
             assert_eq!(&context.named[&"burrito".to_string()].plain, "alpastor");
         } else {
-            panic!("Expected {:?} to match... but it didn't", matcher);
+            panic!("Expected {matcher:?} to match... but it didn't");
         }
     }
 }

--- a/src/app/processing/ansi.rs
+++ b/src/app/processing/ansi.rs
@@ -369,8 +369,15 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deref_ansi_mut_safely() {
+        let bytes: &[u8] = b"\r\xc3\x28";
+        let ansi = AnsiMut::from_bytes(BytesMut::from(bytes));
+        assert!(ansi.starts_with("\r"));
+    }
+
     #[cfg(test)]
-    mod striped_ansi {
+    mod stripped_ansi {
         use super::*;
 
         #[test]

--- a/src/app/processing/send.rs
+++ b/src/app/processing/send.rs
@@ -36,7 +36,7 @@ impl SendTextProcessor {
         F: 'static + Future<Output = io::Result<ProcessResult>> + Send + Sync,
     {
         if matcher.options.consume {
-            panic!("Matcher ({:?}) is unexpectedly `consume`", matcher);
+            panic!("Matcher ({matcher:?}) is unexpectedly `consume`");
         }
 
         self.matchers.push(RegisteredMatcher {

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 
 use crate::{
     app::{
@@ -107,11 +107,9 @@ pub trait ProcessorOutputReceiverFactory: Clone + Send {
 impl TextProcessor {
     pub fn process<R: ProcessorOutputReceiver>(
         &mut self,
-        text: Ansi,
+        mut bytes: Bytes,
         receiver: &mut R,
     ) -> io::Result<()> {
-        let mut bytes = text.into_inner();
-
         while bytes.has_remaining() {
             // Read up until a newline from text; push that onto pending_line...
             let (read, has_full_line) =
@@ -178,7 +176,7 @@ impl TextProcessor {
 
             (MatcherMode::FullLine, full_line)
         } else {
-            (MatcherMode::PartialLine, self.pending_line.clone().into())
+            (MatcherMode::PartialLine, self.pending_line.clone().take())
         };
 
         let to_print = self.perform_and_handle_match(to_match, match_mode)?;

--- a/src/app/processing/text.rs
+++ b/src/app/processing/text.rs
@@ -149,11 +149,9 @@ impl TextProcessor {
 
     fn clean_trailing_cr(&mut self) {
         // Handle trailing carriage returns from previous lines:
-        if self.pending_line.starts_with('\r') {
+        if self.pending_line.valid_utf8().starts_with('\r') {
             // This is particularly important for matchers of whole lines, such as prompts
-            let mut old_bytes = self.pending_line.take_bytes();
-            let trimmed_bytes = old_bytes.split_off(1);
-            self.pending_line = AnsiMut::from_bytes(trimmed_bytes);
+            self.pending_line.drop_leading_bytes(1);
         }
     }
 

--- a/src/cli/ui/prompts.rs
+++ b/src/cli/ui/prompts.rs
@@ -35,7 +35,7 @@ impl PromptsState {
         while self.values.len() <= index {
             self.values.push(None);
         }
-        self.values[index] = Some(content.trim_end_matches("\r\n").into());
+        self.values[index] = Some(content.trim_trailing_newlines());
     }
 }
 

--- a/src/daemon/handlers/connect.rs
+++ b/src/daemon/handlers/connect.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Mutex,
 };
 
+use bytes::Bytes;
 use crossterm::{
     event::{Event, EventStream},
     terminal,
@@ -15,12 +16,9 @@ use futures::{FutureExt as _, StreamExt as _};
 use crate::{
     app::{
         connections::{ConnectionReceiver, Outgoing},
-        processing::{
-            ansi::Ansi,
-            text::{
-                ProcessorOutputReceiver, ProcessorOutputReceiverFactory, SystemMessage,
-                TextProcessor, WindowSizeSource,
-            },
+        processing::text::{
+            ProcessorOutputReceiver, ProcessorOutputReceiverFactory, SystemMessage, TextProcessor,
+            WindowSizeSource,
         },
         processors::register_processors,
         LockableState,
@@ -89,7 +87,7 @@ pub async fn process_connection<T: Transport, R: ProcessorOutputReceiver>(
                     let processor = &connection
                         .state
                         .processor;
-                    handle_received_text(receiver, processor, Ansi::from_bytes(data))?;
+                    handle_received_text(receiver, processor, data)?;
                 },
 
                 TransportEvent::Event(data) => {
@@ -209,7 +207,7 @@ pub async fn handle<TUI: ProcessorOutputReceiverFactory>(
 pub fn handle_received_text<R: ProcessorOutputReceiver>(
     receiver: &mut R,
     processor: &Mutex<TextProcessor>,
-    text: Ansi,
+    text: Bytes,
 ) -> io::Result<()> {
     receiver.begin_chunk()?;
 

--- a/src/testbed.rs
+++ b/src/testbed.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 use crate::app::matchers::MatcherSpec;
 use crate::app::processing::text::ProcessorOutputReceiver;
 use crate::app::{Id, LockableState};
@@ -19,7 +21,7 @@ struct TestBed<R: ProcessorOutputReceiver> {
 }
 
 impl<R: ProcessorOutputReceiver> TestBed<R> {
-    fn receive(&mut self, to_receive: &str) -> io::Result<()> {
+    fn receive(&mut self, to_receive: &'static str) -> io::Result<()> {
         let processor = &self
             .state
             .lock()
@@ -27,7 +29,7 @@ impl<R: ProcessorOutputReceiver> TestBed<R> {
             .connections
             .get_processor(self.id)
             .unwrap();
-        handle_received_text(&mut self.ui, processor, to_receive.into())
+        handle_received_text(&mut self.ui, processor, Bytes::from(to_receive))
     }
 
     fn send(&mut self, to_send: &str) -> io::Result<()> {


### PR DESCRIPTION
We had some convenience stuff that was just not safe, allowing arbitrary conversion of bytes to Ansi to utf8, which could result in crashes if bytes in the Ansi instance were not "complete."

Now, Ansi instances MUST refer to valid utf8 byte strings---only AnsiMut may contain incomplete utf8 sequences, and its interfaces provide safe conversion methods to Ansi instances of only the valid utf8 parts.

- **Add a unit test that crashes dereferencing Ansi w/invalid utf8**
- **Convert "maximally" to utf8, but not necessarily "fully"**
- **Forbid directly dereferencing AnsiMut into &str since it may be invalid**
- **Remove ways of turning arbitrary bytes into Ansi instances**
- **Remove the unsafe slice() method on Ansi that used byte indices**
